### PR TITLE
chore: refactor errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,6 +2016,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
+ "futures-util",
  "http 1.1.0",
  "iceberg",
  "lazy_static",
@@ -2026,6 +2027,8 @@ dependencies = [
  "serde_json",
  "serde_with",
  "strum_macros 0.26.4",
+ "tokio",
+ "tracing",
  "typed-builder 0.18.2",
  "url",
  "uuid",

--- a/crates/iceberg-catalog/src/api/iceberg/v1/config.rs
+++ b/crates/iceberg-catalog/src/api/iceberg/v1/config.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use axum::extract::{Query, State};
 use axum::routing::get;
 use axum::{Extension, Router};
-use iceberg_ext::catalog::rest::CatalogConfig;
+use iceberg_ext::catalog::rest::{CatalogConfig, IcebergErrorResponse};
 
 #[async_trait]
 pub trait Service<S: crate::api::ThreadSafe>
@@ -16,7 +16,7 @@ where
         query: GetConfigQueryParams,
         api_context: ApiContext<S>,
         request_metadata: RequestMetadata,
-    ) -> Result<CatalogConfig>;
+    ) -> Result<CatalogConfig, IcebergErrorResponse>;
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/crates/iceberg-catalog/src/api/iceberg/v1/namespace.rs
+++ b/crates/iceberg-catalog/src/api/iceberg/v1/namespace.rs
@@ -293,7 +293,7 @@ mod tests {
     use crate::request_metadata::RequestMetadata;
     use axum::async_trait;
     use http_body_util::BodyExt;
-    use iceberg_ext::catalog::rest::{ApiIcebergErrorResponse, ErrorModel};
+    use iceberg_ext::catalog::rest::{ErrorModel, IcebergErrorResponse};
 
     #[tokio::test]
     async fn test_namespace_params() {
@@ -497,7 +497,7 @@ mod tests {
         assert_eq!(r.status().as_u16(), 406);
         let bytes = r.collect().await.unwrap().to_bytes();
         let r = String::from_utf8(bytes.to_vec()).unwrap();
-        let error = serde_json::from_str::<ApiIcebergErrorResponse>(&r).unwrap();
+        let error = serde_json::from_str::<IcebergErrorResponse>(&r).unwrap();
         assert_eq!(error.error.message, "[\"this-namespace\"]");
 
         // Test 2: Composed identifier
@@ -511,7 +511,7 @@ mod tests {
         assert_eq!(r.status().as_u16(), 406);
         let bytes = r.collect().await.unwrap().to_bytes();
         let r = String::from_utf8(bytes.to_vec()).unwrap();
-        let error = serde_json::from_str::<ApiIcebergErrorResponse>(&r).unwrap();
+        let error = serde_json::from_str::<IcebergErrorResponse>(&r).unwrap();
         assert_eq!(error.error.message, "[\"accounting\",\"tax\"]");
     }
 }

--- a/crates/iceberg-catalog/src/api/iceberg/v1/namespace.rs
+++ b/crates/iceberg-catalog/src/api/iceberg/v1/namespace.rs
@@ -293,7 +293,7 @@ mod tests {
     use crate::request_metadata::RequestMetadata;
     use axum::async_trait;
     use http_body_util::BodyExt;
-    use iceberg_ext::catalog::rest::{ErrorModel, IcebergErrorResponse};
+    use iceberg_ext::catalog::rest::{ApiIcebergErrorResponse, ErrorModel};
 
     #[tokio::test]
     async fn test_namespace_params() {
@@ -497,7 +497,7 @@ mod tests {
         assert_eq!(r.status().as_u16(), 406);
         let bytes = r.collect().await.unwrap().to_bytes();
         let r = String::from_utf8(bytes.to_vec()).unwrap();
-        let error = serde_json::from_str::<IcebergErrorResponse>(&r).unwrap();
+        let error = serde_json::from_str::<ApiIcebergErrorResponse>(&r).unwrap();
         assert_eq!(error.error.message, "[\"this-namespace\"]");
 
         // Test 2: Composed identifier
@@ -511,7 +511,7 @@ mod tests {
         assert_eq!(r.status().as_u16(), 406);
         let bytes = r.collect().await.unwrap().to_bytes();
         let r = String::from_utf8(bytes.to_vec()).unwrap();
-        let error = serde_json::from_str::<IcebergErrorResponse>(&r).unwrap();
+        let error = serde_json::from_str::<ApiIcebergErrorResponse>(&r).unwrap();
         assert_eq!(error.error.message, "[\"accounting\",\"tax\"]");
     }
 }

--- a/crates/iceberg-catalog/src/catalog/namespace.rs
+++ b/crates/iceberg-catalog/src/catalog/namespace.rs
@@ -283,7 +283,7 @@ pub(crate) fn validate_namespace_ident(namespace: &NamespaceIdent) -> Result<()>
                 "Namespace exceeds maximum depth of {MAX_NAMESPACE_DEPTH}",
             ))
             .r#type("NamespaceDepthExceeded".to_string())
-            .details(vec![format!("Namespace: {:?}", namespace)])
+            .stack(vec![format!("Namespace: {:?}", namespace)])
             .build()
             .into());
     }
@@ -293,7 +293,7 @@ pub(crate) fn validate_namespace_ident(namespace: &NamespaceIdent) -> Result<()>
             .code(StatusCode::BAD_REQUEST.into())
             .message("Namespace parts cannot be empty".to_string())
             .r#type("EmptyNamespacePart".to_string())
-            .details(vec![format!("Namespace: {:?}", namespace)])
+            .stack(vec![format!("Namespace: {:?}", namespace)])
             .build()
             .into());
     }

--- a/crates/iceberg-catalog/src/catalog/namespace.rs
+++ b/crates/iceberg-catalog/src/catalog/namespace.rs
@@ -283,7 +283,7 @@ pub(crate) fn validate_namespace_ident(namespace: &NamespaceIdent) -> Result<()>
                 "Namespace exceeds maximum depth of {MAX_NAMESPACE_DEPTH}",
             ))
             .r#type("NamespaceDepthExceeded".to_string())
-            .stack(Some(vec![format!("Namespace: {:?}", namespace)]))
+            .details(vec![format!("Namespace: {:?}", namespace)])
             .build()
             .into());
     }
@@ -293,7 +293,7 @@ pub(crate) fn validate_namespace_ident(namespace: &NamespaceIdent) -> Result<()>
             .code(StatusCode::BAD_REQUEST.into())
             .message("Namespace parts cannot be empty".to_string())
             .r#type("EmptyNamespacePart".to_string())
-            .stack(Some(vec![format!("Namespace: {:?}", namespace)]))
+            .details(vec![format!("Namespace: {:?}", namespace)])
             .build()
             .into());
     }

--- a/crates/iceberg-catalog/src/catalog/s3_signer.rs
+++ b/crates/iceberg-catalog/src/catalog/s3_signer.rs
@@ -456,7 +456,7 @@ fn validate_uri(
                 .code(http::StatusCode::FORBIDDEN.into())
                 .message("Request URI does not match table location".to_string())
                 .r#type("VirtualHostURIMismatch".to_string())
-                .details(vec![
+                .stack(vec![
                     format!("Expected Key: {table_key_virtual_host:?}"),
                     format!("Actual Key: {request_key:?}"),
                 ])
@@ -475,7 +475,7 @@ fn validate_uri(
                 .code(http::StatusCode::FORBIDDEN.into())
                 .message("Request URI does not match table location".to_string())
                 .r#type("PathStyleHostMismatch".to_string())
-                .details(vec![
+                .stack(vec![
                     format!("Expected Key: {table_key_path_style:?}"),
                     format!("Actual Key: {request_key:?}"),
                 ])

--- a/crates/iceberg-catalog/src/catalog/s3_signer.rs
+++ b/crates/iceberg-catalog/src/catalog/s3_signer.rs
@@ -79,7 +79,7 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore>
                     .code(http::StatusCode::UNAUTHORIZED.into())
                     .message("Unauthorized".to_string())
                     .r#type("InvalidLocation".to_string())
-                    .stack(Some(vec![format!("{e:?}")]))
+                    .source(Some(Box::new(e.error)))
                     .build()
             })?;
 
@@ -124,9 +124,11 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore>
         };
 
         let extend_err = |mut e: IcebergErrorResponse| {
-            e.error.push_to_stack(format!("Table ID: {table_id}"));
-            e.error.push_to_stack(format!("Request URI: {request_url}"));
-            e.error.push_to_stack(format!("Table Location: {location}"));
+            e.error = e
+                .error
+                .append_detail(format!("Table ID: {table_id}"))
+                .append_detail(format!("Request URI: {request_url}"))
+                .append_detail(format!("Table Location: {location}"));
             e
         };
 
@@ -203,7 +205,7 @@ fn sign(
                 .code(http::StatusCode::INTERNAL_SERVER_ERROR.into())
                 .message("Failed to create signing params".to_string())
                 .r#type("FailedToCreateSigningParams".to_string())
-                .stack(Some(vec![e.to_string()]))
+                .source(Some(Box::new(e)))
                 .build()
         })?
         .into();
@@ -233,7 +235,7 @@ fn sign(
             .code(http::StatusCode::BAD_REQUEST.into())
             .message("Request is not signable".to_string())
             .r#type("FailedToCreateSignableRequest".to_string())
-            .stack(Some(vec![e.to_string()]))
+            .source(Some(Box::new(e)))
             .build()
     })?;
 
@@ -243,7 +245,7 @@ fn sign(
                 .code(http::StatusCode::INTERNAL_SERVER_ERROR.into())
                 .message("Failed to sign request".to_string())
                 .r#type("FailedToSignRequest".to_string())
-                .stack(Some(vec![e.to_string()]))
+                .source(Some(Box::new(e)))
                 .build()
         })?
         .into_parts();
@@ -283,7 +285,7 @@ fn partially_decode_uri(uri: &url::Url) -> Result<url::Url> {
                         .code(http::StatusCode::BAD_REQUEST.into())
                         .message("Failed to decode URI segment".to_string())
                         .r#type("FailedToDecodeURISegment".to_string())
-                        .stack(Some(vec![e.to_string()]))
+                        .source(Some(Box::new(e)))
                         .build()
                 })?,
         );
@@ -361,7 +363,7 @@ fn validate_uri(
             .code(http::StatusCode::INTERNAL_SERVER_ERROR.into())
             .message("Failed to parse table location".to_string())
             .r#type("FailedToParseTableLocation".to_string())
-            .stack(Some(vec![e.to_string()]))
+            .source(Some(Box::new(e)))
             .build()
     })?;
     let table_bucket = table_location.host_str().ok_or_else(|| {
@@ -399,7 +401,7 @@ fn validate_uri(
                 .code(http::StatusCode::INTERNAL_SERVER_ERROR.into())
                 .message("Failed to parse storage profile endpoint".to_string())
                 .r#type("FailedToParseStorageProfileEndpoint".to_string())
-                .stack(Some(vec![e.to_string()]))
+                .source(Some(Box::new(e)))
                 .build()
         })?;
 
@@ -454,10 +456,10 @@ fn validate_uri(
                 .code(http::StatusCode::FORBIDDEN.into())
                 .message("Request URI does not match table location".to_string())
                 .r#type("VirtualHostURIMismatch".to_string())
-                .stack(Some(vec![
+                .details(vec![
                     format!("Expected Key: {table_key_virtual_host:?}"),
                     format!("Actual Key: {request_key:?}"),
-                ]))
+                ])
                 .build()
                 .into())
         } else {
@@ -473,10 +475,10 @@ fn validate_uri(
                 .code(http::StatusCode::FORBIDDEN.into())
                 .message("Request URI does not match table location".to_string())
                 .r#type("PathStyleHostMismatch".to_string())
-                .stack(Some(vec![
+                .details(vec![
                     format!("Expected Key: {table_key_path_style:?}"),
                     format!("Actual Key: {request_key:?}"),
-                ]))
+                ])
                 .build()
                 .into())
         } else {

--- a/crates/iceberg-catalog/src/catalog/tables.rs
+++ b/crates/iceberg-catalog/src/catalog/tables.rs
@@ -790,12 +790,12 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore>
                 .code(StatusCode::INTERNAL_SERVER_ERROR.into())
                 .message("Error fetching table ids".to_string())
                 .r#type("TableIdsFetchError".to_string())
-                .stack(Some(
+                .details(
                     vec![e.error.message, e.error.r#type]
                         .into_iter()
-                        .chain(e.error.stack.unwrap_or_default().into_iter())
+                        .chain(e.error.details.into_iter())
                         .collect(),
-                ))
+                )
                 .build()
         })?;
 

--- a/crates/iceberg-catalog/src/catalog/tables.rs
+++ b/crates/iceberg-catalog/src/catalog/tables.rs
@@ -790,10 +790,10 @@ impl<C: Catalog, A: AuthZHandler, S: SecretStore>
                 .code(StatusCode::INTERNAL_SERVER_ERROR.into())
                 .message("Error fetching table ids".to_string())
                 .r#type("TableIdsFetchError".to_string())
-                .details(
+                .stack(
                     vec![e.error.message, e.error.r#type]
                         .into_iter()
-                        .chain(e.error.details.into_iter())
+                        .chain(e.error.stack.into_iter())
                         .collect(),
                 )
                 .build()

--- a/crates/iceberg-catalog/src/implementations/postgres/dbutils.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/dbutils.rs
@@ -3,23 +3,14 @@ use http::StatusCode;
 
 pub(crate) trait DBErrorHandler
 where
-    Self: ToString + Sized,
+    Self: ToString + Sized + Send + Sync + std::error::Error + 'static,
 {
     fn into_error_model(self, message: String) -> ErrorModel {
         ErrorModel::builder()
             .code(StatusCode::INTERNAL_SERVER_ERROR.into())
             .message(message)
             .r#type("DatabaseError".to_string())
-            .stack(Some(vec![self.to_string()]))
-            .build()
-    }
-
-    fn as_error_model(&self, message: String) -> ErrorModel {
-        ErrorModel::builder()
-            .code(StatusCode::INTERNAL_SERVER_ERROR.into())
-            .message(message)
-            .r#type("DatabaseError".to_string())
-            .stack(Some(vec![self.to_string()]))
+            .source(Some(Box::new(self)))
             .build()
     }
 }

--- a/crates/iceberg-catalog/src/implementations/postgres/namespace.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/namespace.rs
@@ -121,7 +121,7 @@ pub(crate) async fn list_namespaces(
                     .code(StatusCode::INTERNAL_SERVER_ERROR.into())
                     .message("Error converting namespace".to_string())
                     .r#type("NamespaceConversionError".to_string())
-                    .stack(Some(vec![e.to_string()]))
+                    .source(Some(Box::new(e)))
                     .build()
                     .into()
             })
@@ -164,7 +164,7 @@ pub(crate) async fn create_namespace(
                 .code(StatusCode::INTERNAL_SERVER_ERROR.into())
                 .message("Error serializing namespace properties".to_string())
                 .r#type("NamespacePropertiesSerializationError".to_string())
-                .stack(Some(vec![e.to_string()]))
+                .source(Some(Box::new(e)))
                 .build()
         })?
     )
@@ -189,7 +189,7 @@ pub(crate) async fn create_namespace(
                     .code(StatusCode::INTERNAL_SERVER_ERROR.into())
                     .message("Error creating namespace".to_string())
                     .r#type("NamespaceCreateError".to_string())
-                    .stack(Some(vec![db_error.to_string()]))
+                    .source(Some(Box::new(db_error)))
                     .build()
             }
         }
@@ -338,7 +338,7 @@ pub(crate) async fn update_namespace_properties(
             .code(StatusCode::INTERNAL_SERVER_ERROR.into())
             .message("Error serializing namespace properties".to_string())
             .r#type("NamespacePropertiesSerializationError".to_string())
-            .stack(Some(vec![e.to_string()]))
+            .source(Some(Box::new(e)))
             .build()
     })?;
 

--- a/crates/iceberg-catalog/src/implementations/postgres/secrets.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/secrets.rs
@@ -43,19 +43,13 @@ impl SecretStore for Server {
                 .code(StatusCode::NOT_FOUND.into())
                 .message("Secret not found".to_string())
                 .r#type("SecretNotFound".to_string())
-                .stack(Some(vec![
-                    format!("secret_id: {}", secret_id),
-                    e.to_string(),
-                ]))
+                .details(vec![format!("secret_id: {}", secret_id), e.to_string()])
                 .build(),
             _ => ErrorModel::builder()
                 .code(StatusCode::INTERNAL_SERVER_ERROR.into())
                 .message("Error fetching secret".to_string())
                 .r#type("SecretFetchError".to_string())
-                .stack(Some(vec![
-                    format!("secret_id: {}", secret_id),
-                    e.to_string(),
-                ]))
+                .details(vec![format!("secret_id: {}", secret_id), e.to_string()])
                 .build(),
         })?;
 
@@ -66,7 +60,7 @@ impl SecretStore for Server {
                     .message("Error parsing secret".to_string())
                     .r#type("SecretParseError".to_string())
                     // We do not add the error here as it might contain sensitive information
-                    .stack(Some(vec![format!("Secret ID: {}", secret_id)]))
+                    .details(vec![format!("Secret ID: {}", secret_id)])
                     .build()
             })?;
 
@@ -89,7 +83,7 @@ impl SecretStore for Server {
                 .message("Error serializing secret".to_string())
                 .r#type("SecretSerializeError".to_string())
                 // Redacted by veil
-                .stack(Some(vec![format!("secret: {:?}", secret)]))
+                .details(vec![format!("secret: {:?}", secret)])
                 .build()
         })?;
 
@@ -109,7 +103,7 @@ impl SecretStore for Server {
                 .code(StatusCode::INTERNAL_SERVER_ERROR.into())
                 .message("Error creating secret".to_string())
                 .r#type("SecretCreateError".to_string())
-                .stack(Some(vec![e.to_string()]))
+                .source(Some(Box::new(e)))
                 .build()
         })?;
 
@@ -132,10 +126,8 @@ impl SecretStore for Server {
                 .code(StatusCode::INTERNAL_SERVER_ERROR.into())
                 .message("Error deleting secret".to_string())
                 .r#type("SecretDeleteError".to_string())
-                .stack(Some(vec![
-                    format!("secret_id: {}", secret_id),
-                    e.to_string(),
-                ]))
+                .details(vec![format!("secret_id: {}", secret_id)])
+                .source(Some(Box::new(e)))
                 .build()
         })?;
 

--- a/crates/iceberg-catalog/src/implementations/postgres/secrets.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/secrets.rs
@@ -43,13 +43,13 @@ impl SecretStore for Server {
                 .code(StatusCode::NOT_FOUND.into())
                 .message("Secret not found".to_string())
                 .r#type("SecretNotFound".to_string())
-                .details(vec![format!("secret_id: {}", secret_id), e.to_string()])
+                .stack(vec![format!("secret_id: {}", secret_id), e.to_string()])
                 .build(),
             _ => ErrorModel::builder()
                 .code(StatusCode::INTERNAL_SERVER_ERROR.into())
                 .message("Error fetching secret".to_string())
                 .r#type("SecretFetchError".to_string())
-                .details(vec![format!("secret_id: {}", secret_id), e.to_string()])
+                .stack(vec![format!("secret_id: {}", secret_id), e.to_string()])
                 .build(),
         })?;
 
@@ -60,7 +60,7 @@ impl SecretStore for Server {
                     .message("Error parsing secret".to_string())
                     .r#type("SecretParseError".to_string())
                     // We do not add the error here as it might contain sensitive information
-                    .details(vec![format!("Secret ID: {}", secret_id)])
+                    .stack(vec![format!("Secret ID: {}", secret_id)])
                     .build()
             })?;
 
@@ -83,7 +83,7 @@ impl SecretStore for Server {
                 .message("Error serializing secret".to_string())
                 .r#type("SecretSerializeError".to_string())
                 // Redacted by veil
-                .details(vec![format!("secret: {:?}", secret)])
+                .stack(vec![format!("secret: {:?}", secret)])
                 .build()
         })?;
 
@@ -126,7 +126,7 @@ impl SecretStore for Server {
                 .code(StatusCode::INTERNAL_SERVER_ERROR.into())
                 .message("Error deleting secret".to_string())
                 .r#type("SecretDeleteError".to_string())
-                .details(vec![format!("secret_id: {}", secret_id)])
+                .stack(vec![format!("secret_id: {}", secret_id)])
                 .source(Some(Box::new(e)))
                 .build()
         })?;

--- a/crates/iceberg-catalog/src/implementations/postgres/tabular.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/tabular.rs
@@ -280,7 +280,7 @@ pub(crate) async fn create_tabular<'a>(
                 .r#type("TableOrViewAlreadyExists".to_string())
                 .build()
         }
-        _ => e.as_error_model(format!("Error creating {typ}")),
+        _ => e.into_error_model(format!("Error creating {typ}")),
     })?)
 }
 
@@ -466,7 +466,7 @@ fn try_parse_namespace_ident(namespace: Vec<String>) -> Result<NamespaceIdent> {
             .code(StatusCode::INTERNAL_SERVER_ERROR.into())
             .message("Error parsing namespace".to_string())
             .r#type("NamespaceParseError".to_string())
-            .stack(Some(vec![e.to_string()]))
+            .source(Some(Box::new(e)))
             .build()
             .into()
     })

--- a/crates/iceberg-catalog/src/implementations/postgres/tabular/table.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/tabular/table.rs
@@ -141,7 +141,7 @@ pub(crate) async fn create_table(
             .code(StatusCode::INTERNAL_SERVER_ERROR.into())
             .message("Error serializing table metadata".to_string())
             .r#type("TableMetadataSerializationError".to_string())
-            .stack(Some(vec![e.to_string()]))
+            .source(Some(Box::new(e)))
             .build()
     })?;
 
@@ -177,7 +177,7 @@ pub(crate) async fn create_table(
     .await
     .map_err(|e| {
         tracing::warn!("Error creating table: {}", e);
-        e.as_error_model("Error creating table".to_string())
+        e.into_error_model("Error creating table".to_string())
     })?;
 
     Ok(CreateTableResponse { table_metadata })
@@ -362,10 +362,10 @@ pub(crate) async fn get_table_metadata_by_s3_location(
             .code(StatusCode::NOT_FOUND.into())
             .message("Table not found".to_string())
             .r#type("NoSuchTableError".to_string())
-            .stack(Some(vec![
+            .details(vec![
                 location.to_string(),
                 format!("Warehouse: {}", warehouse_id),
-            ]))
+            ])
             .build(),
         _ => e.into_error_model("Error fetching table".to_string()),
     })?;
@@ -494,7 +494,7 @@ async fn get_commit_context<'a>(
                 .code(StatusCode::BAD_REQUEST.into())
                 .message("Table identifier not found".to_string())
                 .r#type("TableIdentifierNotFound".to_string())
-                .stack(Some(vec![format!("{:?}", table_ident)]))
+                .details(vec![format!("{:?}", table_ident)])
                 .build()
         })?;
 
@@ -506,7 +506,7 @@ async fn get_commit_context<'a>(
                     .code(StatusCode::NOT_FOUND.into())
                     .message("Table not found".to_string())
                     .r#type("NoSuchTableError".to_string())
-                    .stack(Some(vec![format!("Table Ident {:?}", table_ident)]))
+                    .details(vec![format!("Table Ident {:?}", table_ident)])
                     .build()
             })?;
 
@@ -634,7 +634,7 @@ pub(crate) async fn commit_table_transaction<'a>(
                     .code(StatusCode::INTERNAL_SERVER_ERROR.into())
                     .message("Error serializing table metadata".to_string())
                     .r#type("TableMetadataSerializationError".to_string())
-                    .stack(Some(vec![e.to_string()]))
+                    .source(Some(Box::new(e)))
                     .build()
             })?;
 

--- a/crates/iceberg-catalog/src/implementations/postgres/tabular/table.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/tabular/table.rs
@@ -362,7 +362,7 @@ pub(crate) async fn get_table_metadata_by_s3_location(
             .code(StatusCode::NOT_FOUND.into())
             .message("Table not found".to_string())
             .r#type("NoSuchTableError".to_string())
-            .details(vec![
+            .stack(vec![
                 location.to_string(),
                 format!("Warehouse: {}", warehouse_id),
             ])
@@ -494,7 +494,7 @@ async fn get_commit_context<'a>(
                 .code(StatusCode::BAD_REQUEST.into())
                 .message("Table identifier not found".to_string())
                 .r#type("TableIdentifierNotFound".to_string())
-                .details(vec![format!("{:?}", table_ident)])
+                .stack(vec![format!("{:?}", table_ident)])
                 .build()
         })?;
 
@@ -506,7 +506,7 @@ async fn get_commit_context<'a>(
                     .code(StatusCode::NOT_FOUND.into())
                     .message("Table not found".to_string())
                     .r#type("NoSuchTableError".to_string())
-                    .details(vec![format!("Table Ident {:?}", table_ident)])
+                    .stack(vec![format!("Table Ident {:?}", table_ident)])
                     .build()
             })?;
 

--- a/crates/iceberg-catalog/src/implementations/postgres/tabular/view/load.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/tabular/view/load.rs
@@ -339,7 +339,7 @@ async fn get_namespace_ident_with_empty_support(
             .code(500)
             .message(message)
             .r#type("DatabaseError".to_string())
-            .stack(Some(vec![e.to_string()]))
+            .source(Some(Box::new(e)))
             .build()
     })?;
 

--- a/crates/iceberg-catalog/src/implementations/postgres/warehouse.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/warehouse.rs
@@ -42,7 +42,7 @@ impl ConfigProvider<Catalog> for super::Catalog {
                 .code(StatusCode::INTERNAL_SERVER_ERROR.into())
                 .message("Error fetching warehouse".to_string())
                 .r#type("WarehouseFetchError".to_string())
-                .stack(Some(vec![e.to_string()]))
+                .source(Some(Box::new(e)))
                 .build(),
         })?;
 
@@ -75,7 +75,7 @@ impl ConfigProvider<Catalog> for super::Catalog {
                 .code(StatusCode::INTERNAL_SERVER_ERROR.into())
                 .message("Error fetching warehouse".to_string())
                 .r#type("WarehouseFetchError".to_string())
-                .stack(Some(vec![e.to_string()]))
+                .source(Some(Box::new(e)))
                 .build(),
         })?;
 
@@ -96,7 +96,7 @@ pub(crate) async fn create_warehouse<'a>(
             .code(StatusCode::INTERNAL_SERVER_ERROR.into())
             .message("Error serializing storage profile".to_string())
             .r#type("StorageProfileSerializationError".to_string())
-            .stack(Some(vec![e.to_string()]))
+            .source(Some(Box::new(e)))
             .build()
     })?;
 
@@ -395,7 +395,7 @@ pub(crate) async fn update_storage_profile<'a>(
             .code(StatusCode::INTERNAL_SERVER_ERROR.into())
             .message("Error serializing storage profile".to_string())
             .r#type("StorageProfileSerializationError".to_string())
-            .stack(Some(vec![e.to_string()]))
+            .source(Some(Box::new(e)))
             .build()
     })?;
 

--- a/crates/iceberg-catalog/src/service/mod.rs
+++ b/crates/iceberg-catalog/src/service/mod.rs
@@ -98,7 +98,7 @@ impl FromStr for NamespaceIdentUuid {
                     .code(StatusCode::BAD_REQUEST.into())
                     .message("Provided namespace id is not a valid UUID".to_string())
                     .r#type("NamespaceIDIsNotUUID".to_string())
-                    .stack(Some(vec![e.to_string()]))
+                    .source(Some(Box::new(e)))
                     .build()
             },
         )?))
@@ -143,7 +143,7 @@ impl FromStr for TableIdentUuid {
                 .code(StatusCode::BAD_REQUEST.into())
                 .message("Provided table id is not a valid UUID".to_string())
                 .r#type("TableIDIsNotUUID".to_string())
-                .stack(Some(vec![e.to_string()]))
+                .source(Some(Box::new(e)))
                 .build()
         })?))
     }
@@ -179,7 +179,7 @@ impl FromStr for ProjectIdent {
                 .code(StatusCode::BAD_REQUEST.into())
                 .message("Provided project id is not a valid UUID".to_string())
                 .r#type("ProjectIDIsNotUUID".to_string())
-                .stack(Some(vec![e.to_string()]))
+                .source(Some(Box::new(e)))
                 .build()
         })?))
     }
@@ -266,7 +266,7 @@ impl FromStr for WarehouseIdent {
                 .code(StatusCode::BAD_REQUEST.into())
                 .message("Provided warehouse id is not a valid UUID".to_string())
                 .r#type("WarehouseIDIsNotUUID".to_string())
-                .stack(Some(vec![e.to_string()]))
+                .source(Some(Box::new(e)))
                 .build()
         })?))
     }
@@ -290,7 +290,7 @@ impl TryFrom<Prefix> for WarehouseIdent {
                     value.as_str()
                 ))
                 .r#type("PrefixIsNotWarehouseID".to_string())
-                .stack(Some(vec![e.to_string()]))
+                .source(Some(Box::new(e)))
                 .build()
         })?;
         Ok(WarehouseIdent(prefix))

--- a/crates/iceberg-catalog/src/service/storage/mod.rs
+++ b/crates/iceberg-catalog/src/service/storage/mod.rs
@@ -84,7 +84,7 @@ impl StorageProfile {
                             .code(500)
                             .message("Failed to create file IO".to_string())
                             .r#type("FileIOCreationFailed".to_string())
-                            .details(vec![format!("{:?}", e)])
+                            .stack(vec![format!("{:?}", e)])
                             .build()
                     })?;
                 Ok(file_io)
@@ -183,7 +183,7 @@ impl StorageProfile {
                 .code(code)
                 .message("Storage profile is not S3".to_string())
                 .r#type("StorageProfileNotS3".to_string())
-                .details(vec![format!("Storage Type: {}", self.storage_type())])
+                .stack(vec![format!("Storage Type: {}", self.storage_type())])
                 .build()
                 .into()),
             #[allow(unreachable_patterns)] // More profiles will be added in the future
@@ -191,7 +191,7 @@ impl StorageProfile {
                 .code(code)
                 .message("Storage profile is not S3".to_string())
                 .r#type("StorageProfileNotS3".to_string())
-                .details(vec![format!("Storage Type: {}", self.storage_type())])
+                .stack(vec![format!("Storage Type: {}", self.storage_type())])
                 .build()
                 .into()),
         }
@@ -234,7 +234,7 @@ impl StorageCredential {
                 .code(code)
                 .message("Storage profile is not S3".to_string())
                 .r#type("StorageProfileNotS3".to_string())
-                .details(vec![format!("Storage Type: {}", self.storage_type())])
+                .stack(vec![format!("Storage Type: {}", self.storage_type())])
                 .build()
                 .into()),
         }

--- a/crates/iceberg-catalog/src/service/storage/mod.rs
+++ b/crates/iceberg-catalog/src/service/storage/mod.rs
@@ -84,7 +84,7 @@ impl StorageProfile {
                             .code(500)
                             .message("Failed to create file IO".to_string())
                             .r#type("FileIOCreationFailed".to_string())
-                            .stack(Some(vec![format!("{:?}", e)]))
+                            .details(vec![format!("{:?}", e)])
                             .build()
                     })?;
                 Ok(file_io)
@@ -183,7 +183,7 @@ impl StorageProfile {
                 .code(code)
                 .message("Storage profile is not S3".to_string())
                 .r#type("StorageProfileNotS3".to_string())
-                .stack(Some(vec![format!("Storage Type: {}", self.storage_type())]))
+                .details(vec![format!("Storage Type: {}", self.storage_type())])
                 .build()
                 .into()),
             #[allow(unreachable_patterns)] // More profiles will be added in the future
@@ -191,7 +191,7 @@ impl StorageProfile {
                 .code(code)
                 .message("Storage profile is not S3".to_string())
                 .r#type("StorageProfileNotS3".to_string())
-                .stack(Some(vec![format!("Storage Type: {}", self.storage_type())]))
+                .details(vec![format!("Storage Type: {}", self.storage_type())])
                 .build()
                 .into()),
         }
@@ -234,7 +234,7 @@ impl StorageCredential {
                 .code(code)
                 .message("Storage profile is not S3".to_string())
                 .r#type("StorageProfileNotS3".to_string())
-                .stack(Some(vec![format!("Storage Type: {}", self.storage_type())]))
+                .details(vec![format!("Storage Type: {}", self.storage_type())])
                 .build()
                 .into()),
         }

--- a/crates/iceberg-catalog/src/service/token_verification.rs
+++ b/crates/iceberg-catalog/src/service/token_verification.rs
@@ -16,7 +16,7 @@ use crate::request_metadata::RequestMetadata;
 use axum::Extension;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 use std::str::FromStr;
 use url::Url;
 
@@ -115,7 +115,7 @@ impl Verifier {
                 .message("Failed to decode auth token header.")
                 .code(StatusCode::UNAUTHORIZED.into())
                 .r#type("UnauthorizedError")
-                .stack(Some(vec![e.to_string()]))
+                .source(Some(Box::new(e)))
                 .build()
         })?;
 
@@ -143,7 +143,7 @@ impl Verifier {
                         .message("Failed to decode token.")
                         .code(StatusCode::UNAUTHORIZED.into())
                         .r#type("UnauthorizedError")
-                        .stack(Some(vec![e.to_string()]))
+                        .source(Some(Box::new(e)))
                         .build()
                 })?
                 .claims);
@@ -200,12 +200,15 @@ impl Verifier {
         Ok(validation)
     }
 
-    fn internal_error(e: impl Display, message: &str) -> ErrorModel {
+    fn internal_error(
+        e: impl std::error::Error + Sync + Send + 'static,
+        message: &str,
+    ) -> ErrorModel {
         ErrorModel::builder()
             .message(message)
             .code(StatusCode::INTERNAL_SERVER_ERROR.into())
             .r#type("InternalServerError")
-            .stack(Some(vec![e.to_string()]))
+            .source(Some(Box::new(e)))
             .build()
     }
 }

--- a/crates/iceberg-ext/Cargo.toml
+++ b/crates/iceberg-ext/Cargo.toml
@@ -28,9 +28,12 @@ serde_derive = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_with = { workspace = true }
 strum_macros = { workspace = true }
+tracing = { workspace = true }
 typed-builder = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 lazy_static = { workspace = true }
+tokio = { workspace = true }
+futures-util = { version = "^0.3" }

--- a/crates/iceberg-ext/src/catalog/mod.rs
+++ b/crates/iceberg-ext/src/catalog/mod.rs
@@ -21,7 +21,7 @@ pub mod rest {
 
     mod error;
     pub(crate) use error::impl_into_response;
-    pub use error::{ApiIcebergErrorResponse, Error, ErrorModel, IcebergErrorResponse};
+    pub use error::{Error, ErrorModel, IcebergErrorResponse};
 
     mod table;
     pub use table::{

--- a/crates/iceberg-ext/src/catalog/mod.rs
+++ b/crates/iceberg-ext/src/catalog/mod.rs
@@ -21,7 +21,7 @@ pub mod rest {
 
     mod error;
     pub(crate) use error::impl_into_response;
-    pub use error::{Error, ErrorModel, IcebergErrorResponse};
+    pub use error::{ApiIcebergErrorResponse, Error, ErrorModel, IcebergErrorResponse};
 
     mod table;
     pub use table::{

--- a/crates/iceberg-ext/src/catalog/rest/error.rs
+++ b/crates/iceberg-ext/src/catalog/rest/error.rs
@@ -1,6 +1,9 @@
+use std::error::Error as StdError;
+use std::fmt::{Display, Formatter};
 // macro to implement IntoResponse
-
+use http::StatusCode;
 pub use iceberg::Error;
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "axum")]
 macro_rules! impl_into_response {
@@ -19,7 +22,7 @@ pub(crate) use impl_into_response;
 use typed_builder::TypedBuilder;
 
 /// JSON wrapper for all error responses (non-2xx)
-#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug)]
 pub struct IcebergErrorResponse {
     pub error: ErrorModel,
 }
@@ -32,16 +35,23 @@ impl From<IcebergErrorResponse> for iceberg::Error {
 
 impl From<ErrorModel> for iceberg::Error {
     fn from(value: ErrorModel) -> Self {
-        let mut error = iceberg::Error::new(iceberg::ErrorKind::DataInvalid, value.message)
-            .with_context("type", value.r#type)
+        let mut error = iceberg::Error::new(iceberg::ErrorKind::DataInvalid, &value.message)
+            .with_context("type", &value.r#type)
             .with_context("code", format!("{}", value.code));
-
-        if let Some(stack) = value.stack {
-            error = error.with_context("stack", stack.join("\n"));
-        }
+        error = error.with_context("stack", value.to_string());
 
         error
     }
+}
+
+fn error_chain_fmt(e: impl std::error::Error, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    writeln!(f, "{e}\n")?;
+    let mut current = e.source();
+    while let Some(cause) = current {
+        writeln!(f, "Caused by:\n\t{cause}")?;
+        current = cause.source();
+    }
+    Ok(())
 }
 
 impl From<ErrorModel> for IcebergErrorResponse {
@@ -50,9 +60,27 @@ impl From<ErrorModel> for IcebergErrorResponse {
     }
 }
 
+/// JSON wrapper for all error responses (non-2xx)
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApiIcebergErrorResponse {
+    pub error: ApiError,
+}
+
 /// JSON error payload returned in a response with further details on the error
 #[allow(clippy::module_name_repetitions)]
-#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, TypedBuilder)]
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ApiError {
+    /// Human-readable error message
+    pub message: String,
+    /// Internal type definition of the error
+    pub r#type: String,
+    /// HTTP response code
+    pub code: u16,
+}
+
+/// JSON error payload returned in a response with further details on the error
+#[allow(clippy::module_name_repetitions)]
+#[derive(Default, Debug, TypedBuilder)]
 pub struct ErrorModel {
     /// Human-readable error message
     #[builder(setter(into))]
@@ -62,47 +90,181 @@ pub struct ErrorModel {
     pub r#type: String,
     /// HTTP response code
     pub code: u16,
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub stack: Option<Vec<String>>,
+    pub source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    #[builder(default)]
+    pub details: Vec<String>,
+}
+
+impl StdError for ErrorModel {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.source
+            .as_ref()
+            .map(|s| &**s as &(dyn StdError + 'static))
+    }
+}
+
+impl Display for ErrorModel {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if let Some(source) = self.source.as_ref() {
+            writeln!(f, "{}", self.message)?;
+            // Dereference `source` to get `dyn StdError` and then take a reference to pass
+            error_chain_fmt(&**source, f)?;
+        } else {
+            write!(f, "{}", self.message)?;
+        }
+        Ok(())
+    }
 }
 
 impl ErrorModel {
-    pub fn push_to_stack(&mut self, message: impl Into<String>) -> &mut Self {
-        if let Some(stack) = &mut self.stack {
-            stack.push(message.into());
-        } else {
-            self.stack = Some(vec![message.into()]);
-        }
+    pub fn bad_request(
+        message: impl Into<String>,
+        r#type: impl Into<String>,
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        Self::new(message, r#type, StatusCode::BAD_REQUEST.as_u16(), source)
+    }
 
+    pub fn not_implemented(
+        message: impl Into<String>,
+        r#type: impl Into<String>,
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        Self::new(
+            message,
+            r#type,
+            StatusCode::NOT_IMPLEMENTED.as_u16(),
+            source,
+        )
+    }
+
+    pub fn precondition_failed(
+        message: impl Into<String>,
+        r#type: impl Into<String>,
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        Self::new(
+            message,
+            r#type,
+            StatusCode::PRECONDITION_FAILED.as_u16(),
+            source,
+        )
+    }
+
+    pub fn internal(
+        message: impl Into<String>,
+        r#type: impl Into<String>,
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        Self::new(
+            message,
+            r#type,
+            StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+            source,
+        )
+    }
+
+    pub fn conflict(
+        message: impl Into<String>,
+        r#type: impl Into<String>,
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        Self::new(message, r#type, StatusCode::CONFLICT.as_u16(), source)
+    }
+
+    pub fn not_found(
+        message: impl Into<String>,
+        r#type: impl Into<String>,
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        Self::new(message, r#type, StatusCode::NOT_FOUND.as_u16(), source)
+    }
+
+    pub fn not_allowed(
+        message: impl Into<String>,
+        r#type: impl Into<String>,
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        Self::new(
+            message,
+            r#type,
+            StatusCode::METHOD_NOT_ALLOWED.as_u16(),
+            source,
+        )
+    }
+
+    pub fn forbidden(
+        message: impl Into<String>,
+        r#type: impl Into<String>,
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        Self::new(message, r#type, StatusCode::FORBIDDEN.as_u16(), source)
+    }
+
+    pub fn failed_dependency(
+        message: impl Into<String>,
+        r#type: impl Into<String>,
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        Self::new(
+            message,
+            r#type,
+            StatusCode::FAILED_DEPENDENCY.as_u16(),
+            source,
+        )
+    }
+
+    pub fn new(
+        message: impl Into<String>,
+        r#type: impl Into<String>,
+        code: u16,
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        Self::builder()
+            .message(message)
+            .r#type(r#type)
+            .code(code)
+            .source(source)
+            .build()
+    }
+
+    #[must_use]
+    pub fn append_details(mut self, details: &[String]) -> Self {
+        self.details.extend_from_slice(details);
+        self
+    }
+
+    #[must_use]
+    pub fn append_detail(mut self, detail: impl Into<String>) -> Self {
+        self.details.push(detail.into());
         self
     }
 }
 
 #[cfg(feature = "axum")]
 impl axum::response::IntoResponse for IcebergErrorResponse {
-    fn into_response(mut self) -> axum::http::Response<axum::body::Body> {
-        // ToDo: Better Log handling. kv-log-macro?
-        let error_id = uuid::Uuid::now_v7();
+    fn into_response(self) -> axum::http::Response<axum::body::Body> {
+        let Self { error } = self;
+        let stack = error.to_string();
+        let ErrorModel {
+            message,
+            r#type,
+            code,
+            source: _,
+            details,
+        } = error;
 
-        let console_log = serde_json::json!(
-            {
-                "error_id": error_id.to_string(),
-                "message": self.error.message,
-                "type": self.error.r#type,
-                "code": self.error.code,
-                "stack": self.error.stack
-            }
-        );
-        let code = self.error.code;
+        tracing::info!(%stack, ?details, %message, %r#type, %code, "Error response");
 
-        // Exchange stack for error_id. We don't want the stack
-        // to be exposed to the client
-        self.error.stack = Some(vec![format!("Error ID: {}", error_id)]);
-
-        let mut response = axum::Json(self).into_response();
-
-        log::info!("{}", console_log.to_string());
+        let mut response = axum::Json(ApiIcebergErrorResponse {
+            error: ApiError {
+                message,
+                r#type,
+                code,
+            },
+        })
+        .into_response();
 
         *response.status_mut() = axum::http::StatusCode::from_u16(code)
             .unwrap_or(axum::http::StatusCode::INTERNAL_SERVER_ERROR);
@@ -113,17 +275,43 @@ impl axum::response::IntoResponse for IcebergErrorResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::stream::StreamExt;
 
-    #[test]
-    fn test_iceberg_error_response_serialization() {
-        let json = serde_json::json!({
-        "error": {
+    #[tokio::test]
+    async fn test_iceberg_error_response_serialization() {
+        let val = IcebergErrorResponse {
+            error: ErrorModel {
+                message: "The server does not support this operation".to_string(),
+                r#type: "UnsupportedOperationException".to_string(),
+                code: 406,
+                source: None,
+                details: vec![],
+            },
+        };
+        let resp = axum::response::IntoResponse::into_response(val);
+        assert_eq!(resp.status(), StatusCode::NOT_ACCEPTABLE);
+
+        // Not sure how we'd get the body otherwise
+        let mut b = resp.into_body().into_data_stream();
+        let mut buf = Vec::with_capacity(1024);
+        while let Some(d) = b.next().await {
+            buf.extend_from_slice(d.unwrap().as_ref());
+        }
+        let resp: ApiIcebergErrorResponse = serde_json::from_slice(&buf).unwrap();
+        assert_eq!(
+            resp.error.message,
+            "The server does not support this operation"
+        );
+        assert_eq!(resp.error.r#type, "UnsupportedOperationException");
+        assert_eq!(resp.error.code, 406);
+
+        let json = serde_json::json!({"error": {
             "message": "The server does not support this operation",
             "type": "UnsupportedOperationException",
-            "code": 406}
-        });
+            "code": 406
+        }});
 
-        let resp: IcebergErrorResponse = serde_json::from_value(json.clone()).unwrap();
+        let resp: ApiIcebergErrorResponse = serde_json::from_value(json.clone()).unwrap();
         assert_eq!(serde_json::to_value(resp).unwrap(), json);
     }
 }

--- a/crates/iceberg-ext/src/spec/partition_binder.rs
+++ b/crates/iceberg-ext/src/spec/partition_binder.rs
@@ -127,7 +127,7 @@ impl PartitionSpecBinder {
             message: message.into(),
             r#type: "FailedToBuildPartitionSpec".to_owned(),
             code: StatusCode::CONFLICT.into(),
-            details: vec![],
+            stack: vec![],
             source: None,
         }
     }

--- a/crates/iceberg-ext/src/spec/partition_binder.rs
+++ b/crates/iceberg-ext/src/spec/partition_binder.rs
@@ -127,7 +127,8 @@ impl PartitionSpecBinder {
             message: message.into(),
             r#type: "FailedToBuildPartitionSpec".to_owned(),
             code: StatusCode::CONFLICT.into(),
-            stack: None,
+            details: vec![],
+            source: None,
         }
     }
 

--- a/crates/iceberg-ext/src/spec/table_metadata.rs
+++ b/crates/iceberg-ext/src/spec/table_metadata.rs
@@ -287,12 +287,11 @@ impl TableMetadataAggregate {
                 .with_schema_id(new_schema_id)
                 .build()
                 .map_err(|e| {
-                    ErrorModel::builder()
-                        .code(StatusCode::INTERNAL_SERVER_ERROR.into())
-                        .message("Failed to assign new schema id")
-                        .r#type("FailedToAssignSchemaId")
-                        .stack(Some(vec![e.to_string()]))
-                        .build()
+                    ErrorModel::internal(
+                        "Failed to assign new schema id",
+                        "FailedToAssignSchemaId",
+                        Some(Box::new(e)),
+                    )
                 })?
         };
 
@@ -394,12 +393,11 @@ impl TableMetadataAggregate {
                     .with_fields(sort_order.fields.clone())
                     .build_unbound()
                     .map_err(|e| {
-                        ErrorModel::builder()
-                            .message(e.message())
-                            .code(StatusCode::CONFLICT.into())
-                            .r#type(e.kind().into_static())
-                            .stack(Some(vec![e.to_string()]))
-                            .build()
+                        ErrorModel::conflict(
+                            e.message().to_string(),
+                            e.kind().into_static(),
+                            Some(Box::new(e)),
+                        )
                     })
             })
             .collect::<Result<Vec<SortOrder>>>()?
@@ -557,12 +555,11 @@ impl TableMetadataAggregate {
             .with_fields(sort_order.fields)
             .build(schema)
             .map_err(|e| {
-                ErrorModel::builder()
-                    .message("Failed to bind 'SortOrder'")
-                    .code(StatusCode::CONFLICT.into())
-                    .r#type("FailedToBindSortOrder")
-                    .stack(Some(vec![e.to_string()]))
-                    .build()
+                ErrorModel::conflict(
+                    "Failed to bind 'SortOrder'",
+                    "FailedToBindSortOrder",
+                    Some(Box::new(e)),
+                )
             })?;
 
         sort_order.order_id = self.reuse_or_create_new_sort_id(&sort_order);


### PR DESCRIPTION
fewer changes, add source to error model + variant constructors, doesn't use them everywhere, also decouple internal error from api surface error to avoid any leakage

Partially addresses:

#81 