### PR TITLE
Service health checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1971,6 +1971,7 @@ dependencies = [
  "lazy_static",
  "maplit",
  "openssl",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/iceberg-catalog-bin/src/main.rs
+++ b/crates/iceberg-catalog-bin/src/main.rs
@@ -45,6 +45,7 @@ async fn serve(bind_addr: std::net::SocketAddr) -> Result<(), anyhow::Error> {
     let catalog_state = CatalogState {
         read_pool: read_pool.clone(),
         write_pool: write_pool.clone(),
+        health: Arc::new(Default::default()),
     };
     let secrets_state = SecretsState {
         read_pool,
@@ -135,7 +136,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::Serve {}) => {
             print_info();
             println!("Starting server on 0.0.0.0:8080...");
-            let bind_addr = std::net::SocketAddr::from(([0, 0, 0, 0], 8080));
+            let bind_addr = std::net::SocketAddr::from(([0, 0, 0, 0], 8081));
             serve(bind_addr).await?;
         }
         Some(Commands::Healthcheck {}) => {

--- a/crates/iceberg-catalog/Cargo.toml
+++ b/crates/iceberg-catalog/Cargo.toml
@@ -63,6 +63,7 @@ utoipa = { workspace = true, features = ["uuid"] }
 utoipa-swagger-ui = { workspace = true }
 uuid = { workspace = true }
 veil = { workspace = true }
+rand = "0.8.5"
 
 [dev-dependencies]
 http-body-util = { workspace = true }

--- a/crates/iceberg-catalog/Cargo.toml
+++ b/crates/iceberg-catalog/Cargo.toml
@@ -18,6 +18,7 @@ sqlx = ["dep:sqlx"]
 s3-signer = ["dep:aws-sigv4", "dep:aws-credential-types"]
 router = ["dep:tower-http"]
 nats = ["dep:async-nats"]
+default = ["sqlx-postgres", "s3-signer", "router"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/iceberg-catalog/src/api/iceberg/v1/tables.rs
+++ b/crates/iceberg-catalog/src/api/iceberg/v1/tables.rs
@@ -6,7 +6,6 @@ use crate::api::{
     RenameTableRequest, Result,
 };
 use crate::request_metadata::RequestMetadata;
-use crate::service::health::HealthExt;
 use axum::extract::{Path, Query, State};
 use axum::response::IntoResponse;
 use axum::routing::{get, post};

--- a/crates/iceberg-catalog/src/api/iceberg/v1/tables.rs
+++ b/crates/iceberg-catalog/src/api/iceberg/v1/tables.rs
@@ -6,6 +6,7 @@ use crate::api::{
     RenameTableRequest, Result,
 };
 use crate::request_metadata::RequestMetadata;
+use crate::service::health::HealthExt;
 use axum::extract::{Path, Query, State};
 use axum::response::IntoResponse;
 use axum::routing::{get, post};

--- a/crates/iceberg-catalog/src/catalog/mod.rs
+++ b/crates/iceberg-catalog/src/catalog/mod.rs
@@ -11,7 +11,6 @@ pub use config::Server as ConfigServer;
 pub use namespace::{MAX_NAMESPACE_DEPTH, UNSUPPORTED_NAMESPACE_PROPERTIES};
 
 use crate::api::{iceberg::v1::Prefix, ErrorModel, Result};
-use crate::service::health::{HealthExt, HealthStatus};
 use crate::{
     service::{auth::AuthZHandler, secrets::SecretStore, Catalog},
     WarehouseIdent,

--- a/crates/iceberg-catalog/src/catalog/mod.rs
+++ b/crates/iceberg-catalog/src/catalog/mod.rs
@@ -11,6 +11,7 @@ pub use config::Server as ConfigServer;
 pub use namespace::{MAX_NAMESPACE_DEPTH, UNSUPPORTED_NAMESPACE_PROPERTIES};
 
 use crate::api::{iceberg::v1::Prefix, ErrorModel, Result};
+use crate::service::health::{HealthExt, HealthStatus};
 use crate::{
     service::{auth::AuthZHandler, secrets::SecretStore, Catalog},
     WarehouseIdent,

--- a/crates/iceberg-catalog/src/catalog/views.rs
+++ b/crates/iceberg-catalog/src/catalog/views.rs
@@ -134,7 +134,6 @@ fn validate_view_updates(updates: &Vec<ViewUpdate>) -> Result<()> {
 #[cfg(test)]
 mod test {
     use crate::api::ApiContext;
-    use std::sync::Arc;
 
     use crate::implementations::postgres::namespace::tests::initialize_namespace;
     use crate::implementations::postgres::secrets::Server;
@@ -188,15 +187,8 @@ mod test {
         ApiContext {
             v1_state: State {
                 auth: AllowAllAuthState,
-                catalog: CatalogState {
-                    read_pool: pool.clone(),
-                    write_pool: pool.clone(),
-                    health: Arc::new(Default::default()),
-                },
-                secrets: SecretsState {
-                    read_pool: pool.clone(),
-                    write_pool: pool,
-                },
+                catalog: CatalogState::from_pools(pool.clone(), pool.clone()),
+                secrets: SecretsState::from_pools(pool.clone(), pool),
                 publisher: CloudEventsPublisher::new(tx.clone()),
                 contract_verifiers: ContractVerifiers::new(vec![]),
             },

--- a/crates/iceberg-catalog/src/catalog/views.rs
+++ b/crates/iceberg-catalog/src/catalog/views.rs
@@ -133,8 +133,8 @@ fn validate_view_updates(updates: &Vec<ViewUpdate>) -> Result<()> {
 
 #[cfg(test)]
 mod test {
-
     use crate::api::ApiContext;
+    use std::sync::Arc;
 
     use crate::implementations::postgres::namespace::tests::initialize_namespace;
     use crate::implementations::postgres::secrets::Server;
@@ -191,6 +191,7 @@ mod test {
                 catalog: CatalogState {
                     read_pool: pool.clone(),
                     write_pool: pool.clone(),
+                    health: Arc::new(Default::default()),
                 },
                 secrets: SecretsState {
                     read_pool: pool.clone(),

--- a/crates/iceberg-catalog/src/config.rs
+++ b/crates/iceberg-catalog/src/config.rs
@@ -91,6 +91,10 @@ pub struct DynAppConfig {
 
     // ------------- AUTHORIZATION -------------
     pub openid_provider_uri: Option<Url>,
+
+    // ------------- Health -------------
+    pub health_check_frequency_seconds: u64,
+    pub health_check_jitter_millis: u64,
 }
 
 impl Default for DynAppConfig {
@@ -128,6 +132,8 @@ impl Default for DynAppConfig {
             nats_password: None,
             nats_token: None,
             openid_provider_uri: None,
+            health_check_frequency_seconds: 10,
+            health_check_jitter_millis: 500,
         }
     }
 }

--- a/crates/iceberg-catalog/src/implementations/authz.rs
+++ b/crates/iceberg-catalog/src/implementations/authz.rs
@@ -1,7 +1,6 @@
-use std::collections::HashSet;
-
 use crate::api::{iceberg::v1::NamespaceIdent, Result};
 use crate::request_metadata::RequestMetadata;
+use crate::service::health::HealthExt;
 use crate::{
     implementations::DEFAULT_PROJECT_ID,
     service::{
@@ -10,9 +9,20 @@ use crate::{
     },
     ProjectIdent, WarehouseIdent,
 };
+use async_trait::async_trait;
+use std::collections::HashSet;
 
 #[derive(Clone, Debug, Default)]
 pub struct AllowAllAuthState;
+
+#[async_trait]
+impl HealthExt for AllowAllAuthState {
+    async fn health(&self) -> Vec<crate::service::health::Health> {
+        vec![]
+    }
+
+    async fn update_health(&self) {}
+}
 
 #[derive(Clone, Debug, Default)]
 /// Allow absolutely, gloriously, everything.

--- a/crates/iceberg-catalog/src/implementations/postgres/catalog.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/catalog.rs
@@ -178,7 +178,7 @@ impl Catalog for super::Catalog {
             warehouse_id,
             table,
             include_staged,
-            &catalog_state.read_pool,
+            &catalog_state.read_pool(),
         )
         .await
     }
@@ -210,7 +210,7 @@ impl Catalog for super::Catalog {
             warehouse_id,
             tables,
             include_staged,
-            &catalog_state.read_pool,
+            &catalog_state.read_pool(),
         )
         .await
     }
@@ -304,7 +304,7 @@ impl Catalog for super::Catalog {
         view: &TableIdent,
         catalog_state: Self::State,
     ) -> Result<Option<TableIdentUuid>> {
-        view_ident_to_id(warehouse_id, view, &catalog_state.read_pool).await
+        view_ident_to_id(warehouse_id, view, &catalog_state.read_pool()).await
     }
 
     async fn load_view<'a>(

--- a/crates/iceberg-catalog/src/implementations/postgres/mod.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/mod.rs
@@ -151,19 +151,13 @@ impl ReadWrite {
 
     #[cfg(feature = "sqlx-postgres")]
     async fn health(pool: PgPool) -> HealthStatus {
-        macro_rules! unwrap_or_unhealthy {
-            ($e:expr) => {
-                match $e {
-                    Ok(_) => HealthStatus::Healthy,
-                    Err(e) => {
-                        tracing::warn!(?e, ?pool, "Pool is unhealthy");
-                        HealthStatus::Unhealthy
-                    }
-                }
-            };
+        match sqlx::query("SELECT 1").fetch_one(&pool).await {
+            Ok(_) => HealthStatus::Healthy,
+            Err(e) => {
+                tracing::warn!(?e, ?pool, "Pool is unhealthy");
+                HealthStatus::Unhealthy
+            }
         }
-        unwrap_or_unhealthy!(sqlx::query("SELECT 1").fetch_one(&pool).await);
-        HealthStatus::Healthy
     }
 
     async fn write_health(&self) -> HealthStatus {

--- a/crates/iceberg-catalog/src/implementations/postgres/namespace.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/namespace.rs
@@ -374,6 +374,7 @@ pub(crate) async fn update_namespace_properties(
 pub(crate) mod tests {
     use crate::implementations::postgres::PostgresTransaction;
     use crate::service::{Catalog as _, Transaction as _};
+    use std::sync::Arc;
 
     use super::super::warehouse::test::initialize_warehouse;
     use super::super::Catalog;
@@ -411,6 +412,7 @@ pub(crate) mod tests {
         let state = CatalogState {
             read_pool: pool.clone(),
             write_pool: pool.clone(),
+            health: Arc::new(Default::default()),
         };
 
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
@@ -505,6 +507,7 @@ pub(crate) mod tests {
         let state = CatalogState {
             read_pool: pool.clone(),
             write_pool: pool.clone(),
+            health: Arc::new(Default::default()),
         };
 
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
@@ -526,6 +529,7 @@ pub(crate) mod tests {
         let state = CatalogState {
             read_pool: pool.clone(),
             write_pool: pool.clone(),
+            health: Arc::new(Default::default()),
         };
 
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;

--- a/crates/iceberg-catalog/src/implementations/postgres/tabular.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/tabular.rs
@@ -312,7 +312,7 @@ pub(crate) async fn list_tabulars(
         include_staged,
         typ as _
     )
-    .fetch_all(&catalog_state.read_pool)
+    .fetch_all(&catalog_state.read_pool())
     .await
     .map_err(|e| e.into_error_model("Error fetching tables or views".to_string()))?;
 

--- a/crates/iceberg-catalog/src/implementations/postgres/tabular/table.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/tabular/table.rs
@@ -708,6 +708,7 @@ pub(crate) mod tests {
     use crate::implementations::postgres::warehouse::test::initialize_warehouse;
     use iceberg::spec::{NestedField, PrimitiveType, Schema, UnboundPartitionSpec};
     use iceberg::NamespaceIdent;
+    use std::sync::Arc;
 
     use super::*;
 
@@ -829,6 +830,7 @@ pub(crate) mod tests {
         let state = CatalogState {
             read_pool: pool.clone(),
             write_pool: pool.clone(),
+            health: Arc::new(Default::default()),
         };
 
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
@@ -887,6 +889,7 @@ pub(crate) mod tests {
         let state = CatalogState {
             read_pool: pool.clone(),
             write_pool: pool.clone(),
+            health: Arc::new(Default::default()),
         };
 
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
@@ -960,10 +963,7 @@ pub(crate) mod tests {
 
     #[sqlx::test]
     async fn test_to_id(pool: sqlx::PgPool) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
 
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
         let namespace = NamespaceIdent::from_vec(vec!["my_namespace".to_string()]).unwrap();
@@ -996,10 +996,7 @@ pub(crate) mod tests {
 
     #[sqlx::test]
     async fn test_to_ids(pool: sqlx::PgPool) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
 
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
         let namespace = NamespaceIdent::from_vec(vec!["my_namespace".to_string()]).unwrap();
@@ -1071,10 +1068,7 @@ pub(crate) mod tests {
 
     #[sqlx::test]
     async fn test_rename_without_namespace(pool: sqlx::PgPool) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
 
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
         let table = initialize_table(warehouse_id, state.clone(), false).await;
@@ -1110,10 +1104,7 @@ pub(crate) mod tests {
 
     #[sqlx::test]
     async fn test_rename_with_namespace(pool: sqlx::PgPool) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
 
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
         let table = initialize_table(warehouse_id, state.clone(), false).await;
@@ -1151,10 +1142,7 @@ pub(crate) mod tests {
 
     #[sqlx::test]
     async fn test_list_tables(pool: sqlx::PgPool) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
 
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
         let namespace = NamespaceIdent::from_vec(vec!["my_namespace".to_string()]).unwrap();
@@ -1186,10 +1174,7 @@ pub(crate) mod tests {
 
     #[sqlx::test]
     async fn test_commit_transaction(pool: sqlx::PgPool) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
 
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
         let table1 = initialize_table(warehouse_id, state.clone(), true).await;
@@ -1271,10 +1256,7 @@ pub(crate) mod tests {
 
     #[sqlx::test]
     async fn test_get_metadata_by_location(pool: sqlx::PgPool) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
 
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
         let table = initialize_table(warehouse_id, state.clone(), false).await;
@@ -1319,10 +1301,7 @@ pub(crate) mod tests {
 
     #[sqlx::test]
     async fn test_cannot_get_table_of_inactive_warehouse(pool: sqlx::PgPool) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
 
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
         let table = initialize_table(warehouse_id, state.clone(), false).await;
@@ -1340,10 +1319,7 @@ pub(crate) mod tests {
 
     #[sqlx::test]
     async fn test_drop_table_works(pool: sqlx::PgPool) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
 
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
         let table = initialize_table(warehouse_id, state.clone(), false).await;

--- a/crates/iceberg-catalog/src/implementations/postgres/tabular/view.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/tabular/view.rs
@@ -605,10 +605,7 @@ pub(crate) mod tests {
 
     #[sqlx::test]
     async fn create_view(pool: sqlx::PgPool) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
         let namespace = NamespaceIdent::from_vec(vec!["my_namespace".to_string()]).unwrap();
         initialize_namespace(state.clone(), warehouse_id, &namespace, None).await;
@@ -749,10 +746,7 @@ pub(crate) mod tests {
         NamespaceIdent,
         String,
     ) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
         let namespace = NamespaceIdent::from_vec(vec!["my_namespace".to_string()]).unwrap();
         initialize_namespace(state.clone(), warehouse_id, &namespace, None).await;

--- a/crates/iceberg-catalog/src/implementations/postgres/tabular/view.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/tabular/view.rs
@@ -605,7 +605,7 @@ pub(crate) mod tests {
 
     #[sqlx::test]
     async fn create_view(pool: sqlx::PgPool) {
-let state = CatalogState::from_pools(pool.clone(), pool.clone());
+        let state = CatalogState::from_pools(pool.clone(), pool.clone());
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
         let namespace = NamespaceIdent::from_vec(vec!["my_namespace".to_string()]).unwrap();
         initialize_namespace(state.clone(), warehouse_id, &namespace, None).await;
@@ -668,7 +668,7 @@ let state = CatalogState::from_pools(pool.clone(), pool.clone());
         assert_eq!(view_id, table_uuid);
         assert_eq!(view.name, "myview");
 
-        let mut conn = state.read_pool.acquire().await.unwrap();
+        let mut conn = state.read_pool().acquire().await.unwrap();
         let metadata = load_view(TableIdentUuid::from(created_meta.view_uuid), &mut conn)
             .await
             .unwrap();
@@ -678,14 +678,14 @@ let state = CatalogState::from_pools(pool.clone(), pool.clone());
     #[sqlx::test]
     async fn drop_view(pool: sqlx::PgPool) {
         let (state, created_meta, _, _, _) = prepare_view(pool).await;
-        let mut tx = state.read_pool.begin().await.unwrap();
+        let mut tx = state.write_pool().begin().await.unwrap();
         super::drop_view(created_meta.view_uuid.into(), &mut tx)
             .await
             .unwrap();
         tx.commit().await.unwrap();
         load_view(
             created_meta.view_uuid.into(),
-            &mut state.read_pool.acquire().await.unwrap(),
+            &mut state.write_pool().acquire().await.unwrap(),
         )
         .await
         .expect_err("dropped view should not be loadable");
@@ -700,7 +700,7 @@ let state = CatalogState::from_pools(pool.clone(), pool.clone());
                 namespace: namespace.clone(),
                 name,
             },
-            &state.read_pool,
+            &state.read_pool(),
         )
         .await
         .unwrap();
@@ -717,7 +717,7 @@ let state = CatalogState::from_pools(pool.clone(), pool.clone());
                     namespace,
                     name: "non_existing".to_string(),
                 },
-                &state.read_pool,
+                &state.read_pool(),
             )
             .await
             .unwrap(),
@@ -729,7 +729,7 @@ let state = CatalogState::from_pools(pool.clone(), pool.clone());
     #[sqlx::test]
     async fn drop_view_not_existing(pool: sqlx::PgPool) {
         let (state, _, _, _, _) = prepare_view(pool).await;
-        let mut tx = state.read_pool.begin().await.unwrap();
+        let mut tx = state.write_pool().begin().await.unwrap();
         let e = super::drop_view(Uuid::now_v7().into(), &mut tx)
             .await
             .expect_err("dropping random uuid should not succeed");
@@ -746,7 +746,7 @@ let state = CatalogState::from_pools(pool.clone(), pool.clone());
         NamespaceIdent,
         String,
     ) {
-let state = CatalogState::from_pools(pool.clone(), pool.clone());
+        let state = CatalogState::from_pools(pool.clone(), pool.clone());
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
         let namespace = NamespaceIdent::from_vec(vec!["my_namespace".to_string()]).unwrap();
         initialize_namespace(state.clone(), warehouse_id, &namespace, None).await;

--- a/crates/iceberg-catalog/src/implementations/postgres/warehouse.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/warehouse.rs
@@ -489,10 +489,7 @@ pub(crate) mod test {
 
     #[sqlx::test]
     async fn test_get_warehouse_by_name(pool: sqlx::PgPool) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
 
         let fetched_warehouse_id = Catalog::get_warehouse_by_name(
@@ -508,10 +505,7 @@ pub(crate) mod test {
 
     #[sqlx::test]
     async fn test_list_projects(pool: sqlx::PgPool) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
         let project_id_1 = ProjectIdent::from(uuid::Uuid::new_v4());
         initialize_warehouse(state.clone(), None, Some(&project_id_1)).await;
 
@@ -530,10 +524,7 @@ pub(crate) mod test {
 
     #[sqlx::test]
     async fn test_list_warehouses(pool: sqlx::PgPool) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
         let project_id = ProjectIdent::from(uuid::Uuid::new_v4());
         let warehouse_id_1 = initialize_warehouse(state.clone(), None, Some(&project_id)).await;
 
@@ -547,10 +538,7 @@ pub(crate) mod test {
 
     #[sqlx::test]
     async fn test_list_warehouses_active_filter(pool: sqlx::PgPool) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
         let project_id = ProjectIdent::from(uuid::Uuid::new_v4());
         let warehouse_id_1 = initialize_warehouse(state.clone(), None, Some(&project_id)).await;
 
@@ -596,10 +584,7 @@ pub(crate) mod test {
 
     #[sqlx::test]
     async fn test_rename_warehouse(pool: sqlx::PgPool) {
-        let state = CatalogState {
-            read_pool: pool.clone(),
-            write_pool: pool.clone(),
-        };
+let state = CatalogState::from_pools(pool.clone(), pool.clone());
         let project_id = ProjectIdent::from(uuid::Uuid::new_v4());
         let warehouse_id = initialize_warehouse(state.clone(), None, Some(&project_id)).await;
 

--- a/crates/iceberg-catalog/src/implementations/postgres/warehouse.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/warehouse.rs
@@ -30,7 +30,7 @@ impl ConfigProvider<Catalog> for super::Catalog {
             warehouse_name.to_string(),
             *project_id
         )
-        .fetch_one(&catalog_state.read_pool)
+        .fetch_one(&catalog_state.read_pool())
         .await
         .map_err(|e| match e {
             sqlx::Error::RowNotFound => ErrorModel::builder()
@@ -63,7 +63,7 @@ impl ConfigProvider<Catalog> for super::Catalog {
             "#,
             *warehouse_id
         )
-        .fetch_one(&catalog_state.read_pool)
+        .fetch_one(&catalog_state.read_pool())
         .await
         .map_err(|e| match e {
             sqlx::Error::RowNotFound => ErrorModel::builder()
@@ -172,7 +172,7 @@ pub(crate) async fn list_warehouses(
             &warehouse_ids,
             include_status as Vec<WarehouseStatus>
         )
-        .fetch_all(&catalog_state.read_pool)
+        .fetch_all(&catalog_state.read_pool())
         .await
         .map_err(|e| e.into_error_model("Error fetching warehouses".into()))?
     } else {
@@ -192,7 +192,7 @@ pub(crate) async fn list_warehouses(
             *project_id,
             include_status as Vec<WarehouseStatus>
         )
-        .fetch_all(&catalog_state.read_pool)
+        .fetch_all(&catalog_state.read_pool())
         .await
         .map_err(|e| e.into_error_model("Error fetching warehouses".into()))?
     };
@@ -256,7 +256,7 @@ pub(crate) async fn list_projects(catalog_state: CatalogState) -> Result<HashSet
         FROM warehouse
         "#,
     )
-    .fetch_all(&catalog_state.read_pool)
+    .fetch_all(&catalog_state.read_pool())
     .await
     .map_err(|e| e.into_error_model("Error fetching projects".into()))?;
 
@@ -489,7 +489,7 @@ pub(crate) mod test {
 
     #[sqlx::test]
     async fn test_get_warehouse_by_name(pool: sqlx::PgPool) {
-let state = CatalogState::from_pools(pool.clone(), pool.clone());
+        let state = CatalogState::from_pools(pool.clone(), pool.clone());
         let warehouse_id = initialize_warehouse(state.clone(), None, None).await;
 
         let fetched_warehouse_id = Catalog::get_warehouse_by_name(
@@ -505,7 +505,7 @@ let state = CatalogState::from_pools(pool.clone(), pool.clone());
 
     #[sqlx::test]
     async fn test_list_projects(pool: sqlx::PgPool) {
-let state = CatalogState::from_pools(pool.clone(), pool.clone());
+        let state = CatalogState::from_pools(pool.clone(), pool.clone());
         let project_id_1 = ProjectIdent::from(uuid::Uuid::new_v4());
         initialize_warehouse(state.clone(), None, Some(&project_id_1)).await;
 
@@ -524,7 +524,7 @@ let state = CatalogState::from_pools(pool.clone(), pool.clone());
 
     #[sqlx::test]
     async fn test_list_warehouses(pool: sqlx::PgPool) {
-let state = CatalogState::from_pools(pool.clone(), pool.clone());
+        let state = CatalogState::from_pools(pool.clone(), pool.clone());
         let project_id = ProjectIdent::from(uuid::Uuid::new_v4());
         let warehouse_id_1 = initialize_warehouse(state.clone(), None, Some(&project_id)).await;
 
@@ -538,7 +538,7 @@ let state = CatalogState::from_pools(pool.clone(), pool.clone());
 
     #[sqlx::test]
     async fn test_list_warehouses_active_filter(pool: sqlx::PgPool) {
-let state = CatalogState::from_pools(pool.clone(), pool.clone());
+        let state = CatalogState::from_pools(pool.clone(), pool.clone());
         let project_id = ProjectIdent::from(uuid::Uuid::new_v4());
         let warehouse_id_1 = initialize_warehouse(state.clone(), None, Some(&project_id)).await;
 
@@ -584,7 +584,7 @@ let state = CatalogState::from_pools(pool.clone(), pool.clone());
 
     #[sqlx::test]
     async fn test_rename_warehouse(pool: sqlx::PgPool) {
-let state = CatalogState::from_pools(pool.clone(), pool.clone());
+        let state = CatalogState::from_pools(pool.clone(), pool.clone());
         let project_id = ProjectIdent::from(uuid::Uuid::new_v4());
         let warehouse_id = initialize_warehouse(state.clone(), None, Some(&project_id)).await;
 

--- a/crates/iceberg-catalog/src/lib.rs
+++ b/crates/iceberg-catalog/src/lib.rs
@@ -16,7 +16,7 @@ pub use service::{ProjectIdent, SecretIdent, WarehouseIdent};
 pub use config::CONFIG;
 
 pub mod implementations;
-#[cfg(feature = "router")]
+
 mod request_metadata;
 #[cfg(feature = "router")]
 pub(crate) mod tracing;

--- a/crates/iceberg-catalog/src/service/catalog.rs
+++ b/crates/iceberg-catalog/src/service/catalog.rs
@@ -14,6 +14,7 @@ pub use crate::api::iceberg::v1::{
     NamespaceIdent, Result, TableIdent, UpdateNamespacePropertiesRequest,
     UpdateNamespacePropertiesResponse,
 };
+use crate::service::health::{HealthExt, HealthStatus};
 
 #[async_trait::async_trait]
 pub trait Transaction<D>
@@ -107,7 +108,11 @@ where
     Self: Clone + Send + Sync + 'static,
 {
     type Transaction: Transaction<Self::State>;
-    type State: Clone + Send + Sync + 'static;
+    type State: Clone + Send + Sync + 'static + HealthExt;
+
+    async fn health(&self, state: Self::State) -> Vec<(&'static str, HealthStatus)> {
+        state.health().await
+    }
 
     // Should only return namespaces if the warehouse is active.
     async fn list_namespaces(

--- a/crates/iceberg-catalog/src/service/catalog.rs
+++ b/crates/iceberg-catalog/src/service/catalog.rs
@@ -14,7 +14,7 @@ pub use crate::api::iceberg::v1::{
     NamespaceIdent, Result, TableIdent, UpdateNamespacePropertiesRequest,
     UpdateNamespacePropertiesResponse,
 };
-use crate::service::health::{HealthExt, HealthStatus};
+use crate::service::health::HealthExt;
 
 #[async_trait::async_trait]
 pub trait Transaction<D>
@@ -109,10 +109,6 @@ where
 {
     type Transaction: Transaction<Self::State>;
     type State: Clone + Send + Sync + 'static + HealthExt;
-
-    async fn health(&self, state: Self::State) -> Vec<(&'static str, HealthStatus)> {
-        state.health().await
-    }
 
     // Should only return namespaces if the warehouse is active.
     async fn list_namespaces(

--- a/crates/iceberg-catalog/src/service/health.rs
+++ b/crates/iceberg-catalog/src/service/health.rs
@@ -1,0 +1,25 @@
+use serde::Serialize;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[async_trait::async_trait]
+pub trait HealthExt {
+    async fn health(&self) -> Vec<(&'static str, HealthStatus)>;
+    async fn update_health(&self);
+    async fn update_health_task(&self) {
+        loop {
+            self.update_health().await;
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        }
+    }
+}
+
+#[derive(Clone, Debug, strum::Display, Serialize)]
+pub enum HealthStatus {
+    #[serde(rename = "ok")]
+    Healthy,
+    #[serde(rename = "error")]
+    Unhealthy,
+    #[serde(rename = "unknown")]
+    Unknown,
+}

--- a/crates/iceberg-catalog/src/service/health.rs
+++ b/crates/iceberg-catalog/src/service/health.rs
@@ -1,20 +1,33 @@
+#![allow(clippy::module_name_repetitions)]
+use itertools::{FoldWhile, Itertools};
+use rand::RngCore;
 use serde::Serialize;
+use std::collections::HashMap;
+use std::fmt::Formatter;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use std::time::Duration;
+use tokio::task::JoinHandle;
 
 #[async_trait::async_trait]
-pub trait HealthExt {
-    async fn health(&self) -> Vec<(&'static str, HealthStatus)>;
+pub trait HealthExt: Send + Sync + 'static {
+    async fn health(&self) -> Vec<Health>;
     async fn update_health(&self);
-    async fn update_health_task(&self) {
-        loop {
-            self.update_health().await;
-            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-        }
+    async fn update_health_task(
+        self: Arc<Self>,
+        refresh_interval: Duration,
+        jitter_millis: u64,
+    ) -> JoinHandle<()> {
+        tokio::task::spawn(async move {
+            loop {
+                self.update_health().await;
+                let jitter = { rand::thread_rng().next_u64().min(jitter_millis) };
+                tokio::time::sleep(refresh_interval + Duration::from_millis(jitter)).await;
+            }
+        })
     }
 }
 
-#[derive(Clone, Debug, strum::Display, Serialize)]
+#[derive(Clone, Debug, Copy, strum::Display, Serialize)]
 pub enum HealthStatus {
     #[serde(rename = "ok")]
     Healthy,
@@ -22,4 +35,111 @@ pub enum HealthStatus {
     Unhealthy,
     #[serde(rename = "unknown")]
     Unknown,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct Health {
+    name: &'static str,
+    #[serde(with = "chrono::serde::ts_milliseconds", rename = "lastCheck")]
+    created_at: chrono::DateTime<chrono::Utc>,
+    status: HealthStatus,
+}
+
+impl Health {
+    #[must_use]
+    pub fn now(name: &'static str, status: HealthStatus) -> Self {
+        Self {
+            name,
+            created_at: chrono::Utc::now(),
+            status,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ServiceHealthProvider {
+    providers: Vec<(&'static str, Arc<dyn HealthExt + Sync + Send>)>,
+    check_jitter_millis: u64,
+    check_frequency_seconds: u64,
+}
+
+impl std::fmt::Debug for ServiceHealthProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ServiceHealthProvider")
+            .field(
+                "providers",
+                &self
+                    .providers
+                    .iter()
+                    .map(|(name, _)| *name)
+                    .collect::<Vec<_>>(),
+            )
+            .field("check_jitter_millis", &self.check_jitter_millis)
+            .field("check_frequency_seconds", &self.check_frequency_seconds)
+            .finish()
+    }
+}
+
+impl ServiceHealthProvider {
+    #[must_use]
+    pub fn new(
+        providers: Vec<(&'static str, Arc<dyn HealthExt + Sync + Send>)>,
+        check_frequency_seconds: u64,
+        check_jitter_millis: u64,
+    ) -> Self {
+        Self {
+            providers,
+            check_frequency_seconds,
+            check_jitter_millis,
+        }
+    }
+
+    pub async fn spawn_health_checks(&self) {
+        for (service_name, provider) in &self.providers {
+            let provider = provider.clone();
+            provider
+                .update_health_task(
+                    Duration::from_secs(self.check_frequency_seconds),
+                    self.check_jitter_millis,
+                )
+                .await;
+            tracing::info!("Spawned health provider: {service_name}");
+        }
+    }
+
+    pub async fn collect_health(&self) -> HealthState {
+        let mut services = HashMap::new();
+        let mut all_healthy = true;
+        for (name, provider) in &self.providers {
+            let provider_health = provider.health().await;
+            all_healthy = all_healthy
+                && provider_health
+                    .iter()
+                    .fold_while(true, |mut all_good, s| {
+                        all_good = all_good && matches!(s.status, HealthStatus::Healthy);
+                        if all_good {
+                            FoldWhile::Continue(true)
+                        } else {
+                            FoldWhile::Done(false)
+                        }
+                    })
+                    .into_inner();
+            services.insert(*name, provider_health);
+        }
+
+        HealthState {
+            health: if all_healthy {
+                HealthStatus::Healthy
+            } else {
+                HealthStatus::Unhealthy
+            },
+            services,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct HealthState {
+    pub health: HealthStatus,
+    pub services: HashMap<&'static str, Vec<Health>>,
 }

--- a/crates/iceberg-catalog/src/service/mod.rs
+++ b/crates/iceberg-catalog/src/service/mod.rs
@@ -3,6 +3,7 @@ mod catalog;
 pub mod config;
 pub mod contract_verification;
 pub mod event_publisher;
+pub mod health;
 pub mod secrets;
 pub mod storage;
 pub mod tabular_idents;

--- a/crates/iceberg-catalog/src/service/secrets.rs
+++ b/crates/iceberg-catalog/src/service/secrets.rs
@@ -1,4 +1,5 @@
 use crate::api::Result;
+use crate::service::health::HealthExt;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -57,7 +58,7 @@ pub trait SecretStore
 where
     Self: Clone + Send + Sync + 'static,
 {
-    type State: Sized + Send + Sync + Clone + 'static;
+    type State: Sized + Send + Sync + Clone + 'static + HealthExt;
 
     /// Get the secret for a given warehouse.
     async fn get_secret_by_id<S: SecretInStorage + for<'de> Deserialize<'de>>(


### PR DESCRIPTION
closes #35 

`curl server:8080/health`

```json
{
  "health": "ok",
  "services": {
    "secrets": [
      {
        "name": "read_pool",
        "lastCheck": 1721314813908,
        "status": "ok"
      },
      {
        "name": "write_pool",
        "lastCheck": 1721314813908,
        "status": "ok"
      }
    ],
    "auth": [],
    "catalog": [
      {
        "name": "read_pool",
        "lastCheck": 1721314813940,
        "status": "ok"
      },
      {
        "name": "write_pool",
        "lastCheck": 1721314813940,
        "status": "ok"
      }
    ]
  }
}
```


closes #168 

1. only check db `healthcheck -d`, requires postgres connection envs to be set
2. only check server `healtcheck -s` calls `/health` on `localhost:8080` as previously but inspects the response
3. check db & server `healthcheck -a` combines `-d` and `-s`
4. check if db migrations match binary: `ensure-migrate`, requires postgres connection envs to be set