### PR TITLE
feat(prometheus): add prometheus axum metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper",
+ "hyper 1.3.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -606,6 +606,28 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-prometheus"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b683cbc43010e9a3d72c2f31ca464155ff4f95819e88a32924b0f47a43898978"
+dependencies = [
+ "axum",
+ "bytes",
+ "futures",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "matchit",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "once_cell",
+ "pin-project",
+ "tokio",
+ "tower",
+ "tower-http",
 ]
 
 [[package]]
@@ -1036,6 +1058,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1801,6 +1832,29 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
@@ -1828,7 +1882,7 @@ checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper",
+ "hyper 1.3.1",
  "hyper-util",
  "rustls 0.23.10",
  "rustls-pki-types",
@@ -1846,7 +1900,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.3.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1865,7 +1919,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper",
+ "hyper 1.3.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1954,6 +2008,7 @@ dependencies = [
  "aws-sigv4",
  "axum",
  "axum-extra",
+ "axum-prometheus",
  "chrono",
  "cloudevents-sdk",
  "derive_more",
@@ -1963,6 +2018,7 @@ dependencies = [
  "hostname 0.4.0",
  "http 1.1.0",
  "http-body-util",
+ "hyper 1.3.1",
  "iceberg",
  "iceberg-ext",
  "itertools",
@@ -2356,6 +2412,48 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "metrics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
+dependencies = [
+ "ahash 0.8.11",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
+dependencies = [
+ "base64 0.21.7",
+ "hyper 0.14.30",
+ "indexmap 2.2.6",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -3003,6 +3101,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658fa1faf7a4cc5f057c9ee5ef560f717ad9d8dc66d975267f709624d6e1ab88"
 
 [[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3102,6 +3215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
+dependencies = [
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -3225,7 +3347,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper",
+ "hyper 1.3.1",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -3788,6 +3910,12 @@ dependencies = [
  "thiserror",
  "time",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,7 +2018,6 @@ dependencies = [
  "hostname 0.4.0",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.3.1",
  "iceberg",
  "iceberg-ext",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ iceberg = { git = "https://github.com/hansetag/iceberg-rust.git", branch = "tp/p
 typed-builder = "^0.18"
 strum_macros = "^0.26"
 axum = { version = "^0.7" }
+axum-prometheus = "0.6.1"
 axum-extra = { version = "0.9.3" }
 async-trait = "^0.1"
 env_logger = "^0.11"

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Following options are global and apply to all warehouses:
 | `ICEBERG_REST__BASE_URI`            | `https://example.com:8080/catalog/ `   | Base URL where the catalog is externally reachable. Default: `https://localhost:8080/catalog/`                                                                                                                                 |
 | `ICEBERG_REST__DEFAULT_PROJECT_ID`  | `00000000-0000-0000-0000-000000000000` | The default project ID to use if the user does not specify a project when connecting. We recommend setting the Project-ID only in single Project setups. Each Project can still contain multiple Warehouses. Default: Not set. |
 | `ICEBERG_REST__RESERVED_NAMESPACES` | `system,examples`                      | Reserved Namespaces that cannot be created via the REST interface                                                                                                                                                              |
-
+| `ICEBERG_REST__METRICS_PORT`        | `9000`                                 | Port where the metrics endpoint is reachable. Default: `9000`                                                                                                                                                                  |
 ### Postgres
 
 Configuration parameters if Postgres is used as a backend, you may either provide connection strings or use the `PG_*` environment variables, connection strings take precedence:

--- a/crates/iceberg-catalog-bin/src/main.rs
+++ b/crates/iceberg-catalog-bin/src/main.rs
@@ -102,6 +102,10 @@ async fn serve(bind_addr: std::net::SocketAddr) -> Result<(), anyhow::Error> {
         sinks: cloud_event_sinks,
     };
     let listener = tokio::net::TcpListener::bind(bind_addr).await?;
+
+    let (metrics_layer, metrics_future) =
+        iceberg_catalog::metrics::get_axum_layer(CONFIG.metrics_port)?;
+
     let router = new_full_router::<
         Catalog,
         Catalog,
@@ -120,6 +124,7 @@ async fn serve(bind_addr: std::net::SocketAddr) -> Result<(), anyhow::Error> {
             None
         },
         health_provider,
+        Some(metrics_layer),
     );
 
     let publisher_handle = tokio::task::spawn(async move {
@@ -127,6 +132,14 @@ async fn serve(bind_addr: std::net::SocketAddr) -> Result<(), anyhow::Error> {
             Ok(_) => tracing::info!("Exiting publisher task"),
             Err(e) => tracing::error!("Publisher task failed: {e}"),
         };
+    });
+
+    tokio::task::spawn(|| {
+        tracing::info!(
+            "Starting metrics server listening on 0.0.0.0:{} ...",
+            CONFIG.metrics_port
+        );
+        metrics_future
     });
 
     service_serve(listener, router).await?;

--- a/crates/iceberg-catalog-bin/src/main.rs
+++ b/crates/iceberg-catalog-bin/src/main.rs
@@ -134,12 +134,12 @@ async fn serve(bind_addr: std::net::SocketAddr) -> Result<(), anyhow::Error> {
         };
     });
 
-    tokio::task::spawn(|| {
+    tokio::task::spawn(async move {
         tracing::info!(
             "Starting metrics server listening on 0.0.0.0:{} ...",
             CONFIG.metrics_port
         );
-        metrics_future
+        metrics_future.await
     });
 
     service_serve(listener, router).await?;

--- a/crates/iceberg-catalog-bin/src/main.rs
+++ b/crates/iceberg-catalog-bin/src/main.rs
@@ -104,7 +104,7 @@ async fn serve(bind_addr: std::net::SocketAddr) -> Result<(), anyhow::Error> {
     let listener = tokio::net::TcpListener::bind(bind_addr).await?;
 
     let (metrics_layer, metrics_future) =
-        iceberg_catalog::metrics::get_axum_layer(CONFIG.metrics_port)?;
+        iceberg_catalog::metrics::get_axum_layer_and_install_recorder(CONFIG.metrics_port)?;
 
     let router = new_full_router::<
         Catalog,

--- a/crates/iceberg-catalog/Cargo.toml
+++ b/crates/iceberg-catalog/Cargo.toml
@@ -28,6 +28,7 @@ aws-credential-types = { version = "^1.2", optional = true }
 aws-sigv4 = { version = "^1.2", optional = true }
 axum = { workspace = true }
 axum-extra = { workspace = true, features = ["typed-header"] }
+axum-prometheus = { workspace = true }
 chrono = { workspace = true }
 cloudevents-sdk = { version = "0.7.0" }
 derive_more = { workspace = true }

--- a/crates/iceberg-catalog/src/config.rs
+++ b/crates/iceberg-catalog/src/config.rs
@@ -38,6 +38,7 @@ pub struct DynAppConfig {
     /// This is used as the "uri" and "s3.signer.url"
     /// while generating the Catalog Config
     pub base_uri: url::Url,
+    pub metrics_port: u16,
     /// The default Project ID to use. We recommend setting this
     /// only for singe-project deployments. A single project
     /// can still contain multiple warehouses.
@@ -103,6 +104,7 @@ impl Default for DynAppConfig {
             base_uri: "https://localhost:8080/catalog/"
                 .parse()
                 .expect("Valid URL"),
+            metrics_port: 9000,
             default_project_id: None,
             prefix_template: "{warehouse_id}".to_string(),
             reserved_namespaces: ReservedNamespaces(HashSet::from([

--- a/crates/iceberg-catalog/src/lib.rs
+++ b/crates/iceberg-catalog/src/lib.rs
@@ -18,5 +18,8 @@ pub use config::CONFIG;
 pub mod implementations;
 
 mod request_metadata;
+
+#[cfg(feature = "router")]
+pub mod metrics;
 #[cfg(feature = "router")]
 pub(crate) mod tracing;

--- a/crates/iceberg-catalog/src/metrics.rs
+++ b/crates/iceberg-catalog/src/metrics.rs
@@ -1,0 +1,41 @@
+use axum_prometheus::metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
+use axum_prometheus::{
+    metrics, utils, PrometheusMetricLayer, PrometheusMetricLayerBuilder,
+    AXUM_HTTP_REQUESTS_DURATION_SECONDS, PREFIXED_HTTP_REQUESTS_DURATION_SECONDS,
+};
+use futures::TryFutureExt;
+use std::future::Future;
+use std::pin::Pin;
+
+pub type ExporterFuture = Pin<Box<dyn Future<Output = Result<(), anyhow::Error>> + Send + 'static>>;
+
+/// Creates `PrometheusRecorder` and installs it as the global metrics recorder. Also creates a
+/// `PrometheusMetricLayer` which captures axum requests and an `ExporterFuture` that serves metrics
+/// on a given port.
+///
+/// # Errors
+/// Fails if the `PrometheusBuilder` fails to build.
+pub fn get_axum_layer_and_install_recorder(
+    metrics_port: u16,
+) -> anyhow::Result<(PrometheusMetricLayer<'static>, ExporterFuture)> {
+    let (recorder, exporter) = PrometheusBuilder::new()
+        .set_buckets_for_metric(
+            Matcher::Full(
+                PREFIXED_HTTP_REQUESTS_DURATION_SECONDS
+                    .get()
+                    .map_or(AXUM_HTTP_REQUESTS_DURATION_SECONDS, |s| s.as_str())
+                    .to_string(),
+            ),
+            utils::SECONDS_DURATION_BUCKETS,
+        )?
+        .with_http_listener(([0, 0, 0, 0], metrics_port))
+        .build()?;
+    let handle = recorder.handle();
+    metrics::set_global_recorder(recorder)?;
+
+    let (layer, _) = PrometheusMetricLayerBuilder::new()
+        .with_metrics_from_fn(|| handle)
+        .build_pair();
+
+    Ok((layer, Box::pin(exporter.map_err(|e| anyhow::anyhow!(e)))))
+}


### PR DESCRIPTION
- serves metrics under `0.0.0.0:<ICEBERG_REST__METRICS_PORT>`
- does not serve metrics for calls to metrics
- serves metrics for calls to health
- we may wanna consider moving /health under `ICEBERG_REST__METRICS_PORT` as well

closes #87 