### PR TITLE
fix: Add S3 remote signing "content-md5" for pyiceberg compatability

### DIFF
--- a/crates/iceberg-catalog/src/catalog/s3_signer.rs
+++ b/crates/iceberg-catalog/src/catalog/s3_signer.rs
@@ -22,13 +22,14 @@ use crate::WarehouseIdent;
 const READ_METHODS: &[&str] = &["GET", "HEAD"];
 const WRITE_METHODS: &[&str] = &["PUT", "POST", "DELETE"];
 // Keep only the following headers:
-const HEADERS_TO_SIGN: [&str; 6] = [
+const HEADERS_TO_SIGN: [&str; 7] = [
     "amz-sdk-invocation-id",
     "amz-sdk-request",
     "content-length",
     "content-type",
     "expect",
     "host",
+    "content-md5",
 ];
 
 #[async_trait::async_trait]

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       - ICEBERG_REST__PG_DATABASE_URL_WRITE=postgresql://postgres:postgres@db:5432/postgres
       - ICEBERG_REST__DEFAULT_PROJECT_ID=00000000-0000-0000-0000-000000000000
       - RUST_LOG=info
-    entrypoint: [ "./iceberg-catalog", "serve" ]
+    command: [ "serve" ]
     healthcheck:
       test: [ "CMD", "/home/nonroot/iceberg-catalog", "healthcheck" ]
       interval: 1s

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -15,12 +15,12 @@ services:
   server:
     image: quay.io/hansetag/iceberg-catalog:latest
     environment:
-      - ICEBERG_REST__BASE_URI=http://server:8080/catalog/
+      - ICEBERG_REST__BASE_URI=http://server:8080
       - ICEBERG_REST__PG_ENCRYPTION_KEY=This-is-NOT-Secure!
       - ICEBERG_REST__PG_DATABASE_URL_READ=postgresql://postgres:postgres@db:5432/postgres
       - ICEBERG_REST__PG_DATABASE_URL_WRITE=postgresql://postgres:postgres@db:5432/postgres
       - ICEBERG_REST__DEFAULT_PROJECT_ID=00000000-0000-0000-0000-000000000000
-      - RUST_LOG=info
+      - RUST_LOG=trace,axum=trace,sqlx=trace,iceberg-catalog=trace
     command: [ "serve" ]
     healthcheck:
       test: [ "CMD", "/home/nonroot/iceberg-catalog", "healthcheck" ]


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix(s3signing): Add S3 remote signing "content-md5" for pyiceberg compatability

fix(examples): Fix `ICEBERG_REST__BASE_URI`
END_COMMIT_OVERRIDE