### PR TITLE
fix(kv2): extend docs & fix mismatch between docs and expected envs

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -122,10 +122,10 @@ jobs:
         run: cargo test --no-fail-fast --all-targets --all-features --workspace
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
-          ICEBERG_REST__VAULT__URL: http://localhost:8200
-          ICEBERG_REST__VAULT__USER: test
-          ICEBERG_REST__VAULT__PASSWORD: test
-          ICEBERG_REST__VAULT__SECRET_MOUNT: secret
+          ICEBERG_REST__KV2__URL: http://localhost:8200
+          ICEBERG_REST__KV2__USER: test
+          ICEBERG_REST__KV2__PASSWORD: test
+          ICEBERG_REST__KV2__SECRET_MOUNT: secret
       - name: Doc Test
         run: cargo test --no-fail-fast --doc --all-features --workspace
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ local
 .DS_Store
 env.list
 spark-warehouse
+.idea/
 
 # Created by https://www.toptal.com/developers/gitignore/api/rust,rust-analyzer,visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=rust,rust-analyzer,visualstudiocode

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -2,6 +2,38 @@
 All commits to main should go through a PR. CI checks should pass before merging the PR.
 Before merge commits are squashed. PR titles should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
+## Quickstart
+
+```shell
+# start postgres & vault
+docker run -d --name postgres-15 -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:15
+docker run -d -p 8200:8200 --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' hashicorp/vault
+# set envs
+echo 'export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres' > .env
+echo 'export ICEBERG_REST__PG_ENCRYPTION_KEY="abc"' >> .env
+echo 'export ICEBERG_REST__PG_DATABASE_URL_READ="postgresql://postgres:postgres@localhost/postgres"' >> .env
+echo 'export ICEBERG_REST__PG_DATABASE_URL_WRITE="postgresql://postgres:postgres@localhost/postgres"' >> .env
+echo 'export ICEBERG_REST__KV2__URL="http://localhost:8200"' >> .env
+echo 'export ICEBERG_REST__KV2__USER="test"' >> .env
+echo 'export ICEBERG_REST__KV2__PASSWORD="test"' >> .env
+echo 'export ICEBERG_REST__KV2__SECRET_MOUNT="secret"' >> .env
+source .env
+
+# setup vault
+./tests/vault-setup.sh http://localhost:8200
+
+# migrate db
+cd crates/iceberg-catalog
+sqlx database create && sqlx migrate run
+cd ../..
+
+# run tests
+cargo test --all-features --all-targets
+
+# run clippy
+cargo clippy --all-features --all-targets
+```
+
 
 ## Developing with docker compose
 
@@ -30,6 +62,21 @@ Run:
 ```sh
 sqlx database create
 sqlx migrate run
+```
+
+## KV2 / Vault
+
+This catalog supports KV2 as backend for secrets. This means running all tests via:
+
+```sh
+cargo test --all-features --all-targets
+```
+
+will fail if no vault is running. You can use the following commands to set the vault server up for testing:
+
+```sh
+$ docker run -d -p 8200:8200 --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' hashicorp/vault
+$ ./scripts/vault-setup.sh localhost:8200
 ```
 
 ## Running integration test

--- a/crates/iceberg-catalog-bin/src/serve.rs
+++ b/crates/iceberg-catalog-bin/src/serve.rs
@@ -25,7 +25,7 @@ pub(crate) async fn serve(bind_addr: std::net::SocketAddr) -> Result<(), anyhow:
     let secrets_state: Secrets = match CONFIG.secret_backend {
         SecretBackend::KV2 => iceberg_catalog::implementations::kv2::SecretsState::from_config(
             CONFIG
-                .vault
+                .kv2
                 .as_ref()
                 .ok_or_else(|| anyhow!("Need vault config to use vault as backend"))?,
         )

--- a/crates/iceberg-catalog/src/config.rs
+++ b/crates/iceberg-catalog/src/config.rs
@@ -106,7 +106,7 @@ pub struct DynAppConfig {
     pub health_check_jitter_millis: u64,
 
     // ------------- KV2 -------------
-    pub vault: Option<KV2Config>,
+    pub kv2: Option<KV2Config>,
     // ------------- Secrets -------------
     pub secret_backend: SecretBackend,
 }
@@ -165,7 +165,7 @@ impl Default for DynAppConfig {
             listen_port: 8080,
             health_check_frequency_seconds: 10,
             health_check_jitter_millis: 500,
-            vault: None,
+            kv2: None,
             secret_backend: SecretBackend::Postgres,
         }
     }

--- a/crates/iceberg-catalog/src/implementations/kv2.rs
+++ b/crates/iceberg-catalog/src/implementations/kv2.rs
@@ -262,7 +262,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_read_secret() {
-        let state = SecretsState::from_config(CONFIG.vault.as_ref().unwrap())
+        let state = SecretsState::from_config(CONFIG.kv2.as_ref().unwrap())
             .await
             .unwrap();
 
@@ -284,7 +284,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_secret() {
-        let state = SecretsState::from_config(CONFIG.vault.as_ref().unwrap())
+        let state = SecretsState::from_config(CONFIG.kv2.as_ref().expect("vault cfg missing"))
             .await
             .unwrap();
 
@@ -294,7 +294,10 @@ mod tests {
         }
         .into();
 
-        let secret_id = state.create_secret(secret.clone()).await.unwrap();
+        let secret_id = state
+            .create_secret(secret.clone())
+            .await
+            .expect("create secret failed");
 
         state.delete_secret(&secret_id).await.unwrap();
 

--- a/tests/docker-compose-vault-overlay.yaml
+++ b/tests/docker-compose-vault-overlay.yaml
@@ -2,7 +2,7 @@ services:
   server:
     environment:
       - ICEBERG_REST__SECRET_BACKEND=kv2
-      - ICEBERG_REST__VAULT={url="http://hvault:8200", user="test", password="test", secret_mount="secret"}
+      - ICEBERG_REST__KV2={url="http://hvault:8200", user="test", password="test", secret_mount="secret"}
     depends_on:
       hvault:
         condition: service_healthy

--- a/tests/init_vault.sh
+++ b/tests/init_vault.sh
@@ -1,12 +1,11 @@
 #!/bin/sh
 set -eux
 
-vault login -address http://hvault:8200 myroot
-vault auth  enable -address http://hvault:8200  userpass
+VAULT_ADDR=${1:-http://hvault:8200}
+
+vault login -address "$VAULT_ADDR" myroot
+vault auth enable -address "$VAULT_ADDR" userpass
 echo "path \"secret/*\" { capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\"] }" > /tmp/app.hcl
-vault policy write -address http://hvault:8200 app /tmp/app.hcl
-vault write -address http://hvault:8200 auth/userpass/users/test password=test policies=app
-vault status -address http://hvault:8200
-# grant access to the secrets kv store to test user
-
-
+vault policy write -address "$VAULT_ADDR" app /tmp/app.hcl
+vault write -address "$VAULT_ADDR" auth/userpass/users/test password=test policies=app
+vault status -address "$VAULT_ADDR"


### PR DESCRIPTION
1. add quickstart & vault section to developer guide
2. rename vault to kv2 in a few spots where we missed it in #192, before, the envs described in README.md didn't match what the app expected, I've chosen to align the app to the readme as we're specifically interfacing with the kv2 api, this may be considered breaking