### PR TITLE
chore(kv2): make tests env-var dependent

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -138,6 +138,7 @@ jobs:
         run: cargo test --no-fail-fast --all-targets --all-features --workspace
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+          TEST_KV2: 1
           ICEBERG_REST__KV2__URL: http://localhost:8200
           ICEBERG_REST__KV2__USER: test
           ICEBERG_REST__KV2__PASSWORD: test


### PR DESCRIPTION
removes one external dependency from running unittests, we still run the tests on ci so we keep the guarantees

closes #259 