### PR TITLE
ignore RUSTSEC-2024-0363

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,4 +3,5 @@
 [advisories]
 ignore = [
     "RUSTSEC-2023-0071" # we're using postgres, this is likely a false positive: https://github.com/launchbadge/sqlx/issues/2911
+    "RUSTSEC-2024-0363" # https://github.com/hansetag/iceberg-catalog/issues/280
 ]


### PR DESCRIPTION
Currently, there's no available fix, we should bump sqlx to 0.8.1 as soon as it's here. Until then, CI is either blocked or we ignore the advisory.

https://github.com/hansetag/iceberg-catalog/issues/280