### PR TITLE
fix: make conditional compilation of tests depend on var content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3414,8 +3414,6 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 [[package]]
 name = "needs_env_var"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4993ef217a71dd939d08c47d0230bfca02aeedcf108c46c800eb60caa51dc467"
 
 [[package]]
 name = "nkeys"

--- a/crates/iceberg-catalog/Cargo.toml
+++ b/crates/iceberg-catalog/Cargo.toml
@@ -80,6 +80,6 @@ veil = { workspace = true }
 
 [dev-dependencies]
 http-body-util = { workspace = true }
-needs_env_var = { workspace = true }
+needs_env_var = { git = "https://github.com/twuebi/needs_env_var.git", rev = "bf14242" }
 tower = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/iceberg-catalog/src/implementations/kv2.rs
+++ b/crates/iceberg-catalog/src/implementations/kv2.rs
@@ -257,7 +257,7 @@ fn secret_ident_to_key(secret_id: SecretIdent) -> String {
 mod tests {
     use needs_env_var::needs_env_var;
 
-    #[needs_env_var(TEST_KV2)]
+    #[needs_env_var(TEST_KV2 = 1)]
     mod kv2 {
         use crate::service::storage::{S3Credential, StorageCredential};
         use crate::CONFIG;

--- a/crates/iceberg-catalog/src/service/storage/az.rs
+++ b/crates/iceberg-catalog/src/service/storage/az.rs
@@ -742,7 +742,7 @@ mod test {
     use super::*;
     use needs_env_var::needs_env_var;
 
-    #[needs_env_var(TEST_AZURE)]
+    #[needs_env_var(TEST_AZURE = 1)]
     mod azure_tests {
         use crate::service::storage::{AzCredential, AzdlsProfile};
         use crate::service::storage::{StorageCredential, StorageProfile};

--- a/crates/iceberg-catalog/src/service/storage/s3.rs
+++ b/crates/iceberg-catalog/src/service/storage/s3.rs
@@ -859,7 +859,7 @@ mod test {
         assert_eq!(location.to_string(), expected);
     }
 
-    #[needs_env_var(TEST_MINIO)]
+    #[needs_env_var(TEST_MINIO = 1)]
     mod minio {
         use crate::service::storage::{
             S3Credential, S3Flavor, S3Profile, StorageCredential, StorageProfile,
@@ -897,7 +897,7 @@ mod test {
         }
     }
 
-    #[needs_env_var(TEST_AWS)]
+    #[needs_env_var(TEST_AWS = 1)]
     mod aws {
         use crate::service::storage::{StorageCredential, StorageProfile};
 


### PR DESCRIPTION
currently, we have failures in CI for non-maintainer PRs (https://github.com/hansetag/iceberg-catalog/pull/309), this is due to `needs_env_var` checking for absence / presence of an env while github actions ends up mounting an empty secret for non-maintainer PRs. This PR moves us from crates.io `needs_env_var` to a fork.

There's a PR at `needs_env_var` to upstream the matching logic: https://github.com/HerrMuellerluedenscheid/needs_env_var/pull/2