### PR TITLE
feat!: make locations include warehouse ids

### DIFF
--- a/crates/iceberg-catalog/src/api/management/v1/warehouse.rs
+++ b/crates/iceberg-catalog/src/api/management/v1/warehouse.rs
@@ -575,8 +575,8 @@ impl axum::response::IntoResponse for GetWarehouseResponse {
     }
 }
 
-impl From<crate::service::GetWarehouseResponse> for GetWarehouseResponse {
-    fn from(warehouse: crate::service::GetWarehouseResponse) -> Self {
+impl From<crate::service::Warehouse> for GetWarehouseResponse {
+    fn from(warehouse: crate::service::Warehouse) -> Self {
         Self {
             id: warehouse.id.to_uuid(),
             name: warehouse.name,

--- a/crates/iceberg-catalog/src/catalog/views/commit.rs
+++ b/crates/iceberg-catalog/src/catalog/views/commit.rs
@@ -17,8 +17,8 @@ use crate::service::event_publisher::EventMetadata;
 use crate::service::storage::{StorageLocations as _, StoragePermissions};
 use crate::service::tabular_idents::TabularIdentUuid;
 use crate::service::{
-    auth::AuthZHandler, secrets::SecretStore, Catalog, GetWarehouseResponse, State, Transaction,
-    ViewMetadataWithLocation,
+    auth::AuthZHandler, secrets::SecretStore, Catalog, State, Transaction,
+    ViewMetadataWithLocation, Warehouse,
 };
 use http::StatusCode;
 use iceberg::spec::{AppendViewVersion, ViewMetadataBuilder};
@@ -150,7 +150,7 @@ pub(crate) async fn commit_view<C: Catalog, A: AuthZHandler, S: SecretStore>(
 
     let mut transaction = C::Transaction::begin_write(state.v1_state.catalog).await?;
 
-    let GetWarehouseResponse {
+    let Warehouse {
         id: _,
         name: _,
         project_id: _,

--- a/crates/iceberg-catalog/src/catalog/views/create.rs
+++ b/crates/iceberg-catalog/src/catalog/views/create.rs
@@ -73,17 +73,13 @@ pub(crate) async fn create_view<C: Catalog, A: AuthZHandler, S: SecretStore>(
     let mut t = C::Transaction::begin_write(state.v1_state.catalog.clone()).await?;
     let namespace = C::get_namespace(warehouse_id, &namespace, t.transaction()).await?;
     let warehouse = C::get_warehouse(warehouse_id, t.transaction()).await?;
-    let storage_profile = warehouse.storage_profile;
+    let storage_profile = &warehouse.storage_profile;
     require_active_warehouse(warehouse.status)?;
 
     let view_id: TabularIdentUuid = TabularIdentUuid::View(uuid::Uuid::now_v7());
 
-    let view_location = determine_tabular_location(
-        &namespace,
-        request.location.clone(),
-        view_id,
-        &storage_profile,
-    )?;
+    let view_location =
+        determine_tabular_location(&namespace, request.location.clone(), view_id, &warehouse)?;
 
     // Update the request for event
     let mut request = request;

--- a/crates/iceberg-catalog/src/catalog/views/create.rs
+++ b/crates/iceberg-catalog/src/catalog/views/create.rs
@@ -78,7 +78,7 @@ pub(crate) async fn create_view<C: Catalog, A: AuthZHandler, S: SecretStore>(
 
     let view_id: TabularIdentUuid = TabularIdentUuid::View(uuid::Uuid::now_v7());
 
-    let view_location =
+    let (view_location, view_id) =
         determine_tabular_location(&namespace, request.location.clone(), view_id, &warehouse)?;
 
     // Update the request for event

--- a/crates/iceberg-catalog/src/catalog/views/load.rs
+++ b/crates/iceberg-catalog/src/catalog/views/load.rs
@@ -8,7 +8,7 @@ use crate::request_metadata::RequestMetadata;
 use crate::service::auth::AuthZHandler;
 use crate::service::storage::{StorageCredential, StoragePermissions};
 use crate::service::{Catalog, SecretStore, State, Transaction, ViewMetadataWithLocation};
-use crate::service::{GetWarehouseResponse, Result};
+use crate::service::{Result, Warehouse};
 use http::StatusCode;
 use iceberg_ext::catalog::rest::{ErrorModel, LoadViewResult};
 use iceberg_ext::configs::Location;
@@ -63,7 +63,7 @@ pub(crate) async fn load_view<C: Catalog, A: AuthZHandler, S: SecretStore>(
     })?;
     let mut transaction = C::Transaction::begin_read(state.v1_state.catalog).await?;
 
-    let GetWarehouseResponse {
+    let Warehouse {
         id: _,
         name: _,
         project_id: _,

--- a/crates/iceberg-catalog/src/implementations/postgres/catalog.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/catalog.rs
@@ -22,8 +22,8 @@ use crate::implementations::postgres::tabular::{list_tabulars, mark_tabular_as_d
 use crate::service::tabular_idents::{TabularIdentOwned, TabularIdentUuid};
 use crate::service::{
     CreateNamespaceRequest, CreateNamespaceResponse, CreateTableRequest, DeletionDetails,
-    GetWarehouseResponse, ListFlags, ListNamespacesQuery, ListNamespacesResponse, NamespaceIdent,
-    Result, TableIdent, WarehouseStatus,
+    ListFlags, ListNamespacesQuery, ListNamespacesResponse, NamespaceIdent, Result, TableIdent,
+    Warehouse, WarehouseStatus,
 };
 use crate::{
     api::iceberg::v1::{PaginatedTabulars, PaginationQuery},
@@ -67,7 +67,7 @@ impl Catalog for super::PostgresCatalog {
     async fn get_warehouse<'a>(
         warehouse_id: WarehouseIdent,
         transaction: <Self::Transaction as Transaction<CatalogState>>::Transaction<'a>,
-    ) -> Result<GetWarehouseResponse> {
+    ) -> Result<Warehouse> {
         get_warehouse(warehouse_id, transaction).await
     }
 
@@ -239,7 +239,7 @@ impl Catalog for super::PostgresCatalog {
         include_inactive: Option<Vec<WarehouseStatus>>,
         warehouse_id_filter: Option<&HashSet<WarehouseIdent>>,
         catalog_state: Self::State,
-    ) -> Result<Vec<GetWarehouseResponse>> {
+    ) -> Result<Vec<Warehouse>> {
         list_warehouses(
             project_id,
             include_inactive,

--- a/crates/iceberg-catalog/src/implementations/postgres/warehouse.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/warehouse.rs
@@ -1,7 +1,7 @@
 use super::dbutils::DBErrorHandler as _;
 use crate::api::{CatalogConfig, ErrorModel, Result};
 use crate::service::config::ConfigProvider;
-use crate::service::{GetWarehouseResponse, WarehouseStatus};
+use crate::service::{Warehouse, WarehouseStatus};
 use crate::{service::storage::StorageProfile, ProjectIdent, SecretIdent, WarehouseIdent};
 use http::StatusCode;
 use sqlx::Error;
@@ -115,7 +115,7 @@ pub(crate) async fn list_warehouses(
     include_status: Option<Vec<WarehouseStatus>>,
     warehouse_id_filter: Option<&HashSet<WarehouseIdent>>,
     catalog_state: CatalogState,
-) -> Result<Vec<GetWarehouseResponse>> {
+) -> Result<Vec<Warehouse>> {
     #[derive(sqlx::FromRow, Debug, PartialEq)]
     struct WarehouseRecord {
         warehouse_id: uuid::Uuid,
@@ -197,7 +197,7 @@ pub(crate) async fn list_warehouses(
                 DbTabularDeleteProfile::Hard => TabularDeleteProfile::Hard {},
             };
 
-            Ok(GetWarehouseResponse {
+            Ok(Warehouse {
                 id: warehouse.warehouse_id.into(),
                 name: warehouse.warehouse_name,
                 project_id,
@@ -213,7 +213,7 @@ pub(crate) async fn list_warehouses(
 pub(crate) async fn get_warehouse<'a>(
     warehouse_id: WarehouseIdent,
     transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-) -> Result<GetWarehouseResponse> {
+) -> Result<Warehouse> {
     let warehouse = sqlx::query!(
         r#"
         SELECT 
@@ -248,7 +248,7 @@ pub(crate) async fn get_warehouse<'a>(
         DbTabularDeleteProfile::Hard => TabularDeleteProfile::Hard {},
     };
 
-    Ok(GetWarehouseResponse {
+    Ok(Warehouse {
         id: warehouse_id,
         name: warehouse.warehouse_name,
         project_id: ProjectIdent::from(warehouse.project_id),

--- a/crates/iceberg-catalog/src/service/mod.rs
+++ b/crates/iceberg-catalog/src/service/mod.rs
@@ -13,10 +13,10 @@ pub mod token_verification;
 pub use catalog::{
     Catalog, CommitTableResponse, CreateNamespaceRequest, CreateNamespaceResponse,
     CreateTableRequest, CreateTableResponse, DeletionDetails, DropFlags, GetNamespaceResponse,
-    GetStorageConfigResponse, GetTableMetadataResponse, GetWarehouseResponse, ListFlags,
-    ListNamespacesQuery, ListNamespacesResponse, LoadTableResponse, NamespaceIdent, Result,
-    TableCommit, TableIdent, Transaction, UpdateNamespacePropertiesRequest,
-    UpdateNamespacePropertiesResponse, ViewMetadataWithLocation,
+    GetStorageConfigResponse, GetTableMetadataResponse, ListFlags, ListNamespacesQuery,
+    ListNamespacesResponse, LoadTableResponse, NamespaceIdent, Result, TableCommit, TableIdent,
+    Transaction, UpdateNamespacePropertiesRequest, UpdateNamespacePropertiesResponse,
+    ViewMetadataWithLocation, Warehouse,
 };
 use std::ops::Deref;
 
@@ -238,6 +238,12 @@ pub enum WarehouseStatus {
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[cfg_attr(feature = "sqlx", sqlx(transparent))]
 pub struct WarehouseIdent(pub(crate) uuid::Uuid);
+
+impl Default for WarehouseIdent {
+    fn default() -> Self {
+        Self(uuid::Uuid::now_v7())
+    }
+}
 
 impl WarehouseIdent {
     #[must_use]

--- a/crates/iceberg-catalog/src/service/storage/az.rs
+++ b/crates/iceberg-catalog/src/service/storage/az.rs
@@ -741,6 +741,7 @@ mod test {
 
     use super::*;
     use needs_env_var::needs_env_var;
+    use uuid::Uuid;
 
     #[needs_env_var(TEST_AZURE = 1)]
     mod azure_tests {
@@ -814,14 +815,17 @@ mod test {
 
         let sp: StorageProfile = profile.clone().into();
 
+        let warehouse_id = WarehouseIdent::from(Uuid::now_v7());
         let namespace_id = NamespaceIdentUuid::from(uuid::Uuid::now_v7());
         let table_id = TabularIdentUuid::Table(uuid::Uuid::now_v7());
-        let namespace_location = sp.default_namespace_location(namespace_id).unwrap();
+        let namespace_location = sp
+            .default_namespace_location(warehouse_id, namespace_id)
+            .unwrap();
 
         let location = sp.default_tabular_location(&namespace_location, table_id);
         assert_eq!(
             location.to_string(),
-            format!("abfss://filesystem@account.dfs.core.windows.net/test_prefix/{namespace_id}/{table_id}")
+            format!("abfss://filesystem@account.dfs.core.windows.net/test_prefix/{warehouse_id}/{namespace_id}/{table_id}")
         );
 
         let mut profile = profile.clone();
@@ -829,11 +833,13 @@ mod test {
         profile.host = Some("blob.com".to_string());
         let sp: StorageProfile = profile.into();
 
-        let namespace_location = sp.default_namespace_location(namespace_id).unwrap();
+        let namespace_location = sp
+            .default_namespace_location(warehouse_id, namespace_id)
+            .unwrap();
         let location = sp.default_tabular_location(&namespace_location, table_id);
         assert_eq!(
             location.to_string(),
-            format!("abfss://filesystem@account.blob.com/{namespace_id}/{table_id}")
+            format!("abfss://filesystem@account.blob.com/{warehouse_id}/{namespace_id}/{table_id}")
         );
     }
 

--- a/crates/iceberg-catalog/src/service/storage/s3.rs
+++ b/crates/iceberg-catalog/src/service/storage/s3.rs
@@ -758,6 +758,7 @@ mod test {
         NamespaceIdentUuid,
     };
     use needs_env_var::needs_env_var;
+    use uuid::Uuid;
 
     #[test]
     fn test_is_valid_bucket_name() {
@@ -806,25 +807,30 @@ mod test {
         };
         let sp: StorageProfile = profile.clone().into();
 
+        let warehouse_id = WarehouseIdent::from(Uuid::now_v7());
         let namespace_id = NamespaceIdentUuid::from(uuid::Uuid::now_v7());
         let table_id = TabularIdentUuid::Table(uuid::Uuid::now_v7());
-        let namespace_location = sp.default_namespace_location(namespace_id).unwrap();
+        let namespace_location = sp
+            .default_namespace_location(warehouse_id, namespace_id)
+            .unwrap();
 
         let location = sp.default_tabular_location(&namespace_location, table_id);
         assert_eq!(
             location.to_string(),
-            format!("s3://test-bucket/test_prefix/{namespace_id}/{table_id}")
+            format!("s3://test-bucket/test_prefix/{warehouse_id}/{namespace_id}/{table_id}")
         );
 
         let mut profile = profile.clone();
         profile.key_prefix = None;
         let sp: StorageProfile = profile.into();
 
-        let namespace_location = sp.default_namespace_location(namespace_id).unwrap();
+        let namespace_location = sp
+            .default_namespace_location(warehouse_id, namespace_id)
+            .unwrap();
         let location = sp.default_tabular_location(&namespace_location, table_id);
         assert_eq!(
             location.to_string(),
-            format!("s3://test-bucket/{namespace_id}/{table_id}")
+            format!("s3://test-bucket/{warehouse_id}/{namespace_id}/{table_id}")
         );
     }
 

--- a/crates/iceberg-ext/src/configs/primitives/location.rs
+++ b/crates/iceberg-ext/src/configs/primitives/location.rs
@@ -87,6 +87,11 @@ impl Location {
 
         self.to_string().starts_with(other_folder.as_str())
     }
+
+    #[must_use]
+    pub fn lstrip(&self, prefix: &str) -> String {
+        self.to_string().trim_start_matches(prefix).to_string()
+    }
 }
 
 impl ConfigProperty for Location {

--- a/tests/python/tests/test_spark.py
+++ b/tests/python/tests/test_spark.py
@@ -1,3 +1,5 @@
+import uuid
+
 import conftest
 import pandas as pd
 import pytest
@@ -523,8 +525,9 @@ def test_custom_location(spark, namespace, warehouse: conftest.Warehouse):
         (*namespace.name, "my_table")
     ).location()
 
-    # Replace element behind the last slash with "custom_location"
-    custom_location = default_location.rsplit("/", 1)[0] + "/custom_location"
+    # Replace element behind the last slash with a random uuid
+    table_id = str(uuid.uuid4())
+    custom_location = default_location.rsplit("/", 1)[0] + "/" + table_id
 
     # Create a table with a custom location
     spark.sql(
@@ -545,3 +548,4 @@ def test_custom_location(spark, namespace, warehouse: conftest.Warehouse):
     )
     assert loaded_table.location() == custom_location
     assert loaded_table.metadata_location.startswith(custom_location)
+    assert loaded_table.metadata.table_uuid == table_id


### PR DESCRIPTION
prep for #321 

This constrains location requests in such a way that each location can only ever be used by a single tabular. This is achieved by rejecting any location that is not of shape:

`{warehouse_location}/{namespace_id}/<some_uuid>`

If a location is specified, we take the last path segment, i.e. `<some_uuid>` from above and use that as our table id. That way the unique constraint on tabular_id enforces the unique location for us.